### PR TITLE
fix: 🐛 resume animation playback from last progress point

### DIFF
--- a/.changeset/dirty-planes-repair.md
+++ b/.changeset/dirty-planes-repair.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+fix: 🐛 ensure smooth frame transition in setFrame for reverse and bounce modes

--- a/.changeset/ninety-peaches-divide.md
+++ b/.changeset/ninety-peaches-divide.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+fix: 🐛 Reset elapsedTime for loop/bounce continuity

--- a/.changeset/violet-hairs-rule.md
+++ b/.changeset/violet-hairs-rule.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+fix: 🐛 Resume from correct progress on play

--- a/.changeset/yellow-windows-marry.md
+++ b/.changeset/yellow-windows-marry.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+fix: 🐛 Smooth frame transition on speed change

--- a/apps/dotlottie-web-example/src/main.ts
+++ b/apps/dotlottie-web-example/src/main.ts
@@ -172,7 +172,7 @@ fetch('/hamster.lottie')
     });
 
     dotLottie.addEventListener('frame', (event) => {
-      const frame = parseFloat(event.currentFrame).toFixed(2);
+      const frame = parseFloat(event.currentFrame.toFixed(2));
 
       frameSlider.value = frame.toString();
       currentFrameSpan.textContent = frame.toString();

--- a/apps/dotlottie-web-example/src/main.ts
+++ b/apps/dotlottie-web-example/src/main.ts
@@ -125,8 +125,6 @@ fetch('/hamster.lottie')
 
     stopButton.addEventListener('click', () => {
       dotLottie.stop();
-      playPauseButton.innerText = 'Play';
-      frameSlider.value = '0';
     });
 
     frameSlider.addEventListener('mousedown', () => {
@@ -193,6 +191,8 @@ fetch('/hamster.lottie')
 
     dotLottie.addEventListener('stop', (event) => {
       console.log(event);
+
+      playPauseButton.innerText = 'Play';
     });
   })
   .catch((error) => {

--- a/apps/dotlottie-web-example/src/main.ts
+++ b/apps/dotlottie-web-example/src/main.ts
@@ -38,7 +38,7 @@ app.innerHTML = `
     <button id="stop" class="control-button">Stop</button>
     
     <label for="frameSlider">Frame: <span id="current-frame">0</span></label>
-    <input type="range" id="frameSlider" min="0" step="1" />
+    <input type="range" id="frameSlider" min="0" step="0.1" />
 
     <label for="loopToggle">Loop: </label>
     <input type="checkbox" id="loopToggle" checked />
@@ -172,10 +172,10 @@ fetch('/hamster.lottie')
     });
 
     dotLottie.addEventListener('frame', (event) => {
-      const roundedFrame = Math.round(event.currentFrame);
+      const frame = parseFloat(event.currentFrame).toFixed(2);
 
-      frameSlider.value = roundedFrame.toString();
-      currentFrameSpan.textContent = roundedFrame.toString();
+      frameSlider.value = frame.toString();
+      currentFrameSpan.textContent = frame.toString();
     });
 
     dotLottie.addEventListener('loop', (event) => {

--- a/apps/dotlottie-web-example/src/main.ts
+++ b/apps/dotlottie-web-example/src/main.ts
@@ -44,6 +44,7 @@ app.innerHTML = `
     <input type="checkbox" id="loopToggle" checked />
     <label for="speed" class="speed-label">Speed: <span id="speed-value">x1</span></label>
     <input type="range" id="speed" min="0.1" max="5" step="0.1" value="1" class="speed-slider" />
+    <button id="jump" class="control-button">Jump</button>
     <button id="destroy" class="control-button" style="background: #cd3434;">Destroy</button>
     <button id="reload" class="control-button">Reload</button>
   </div>
@@ -99,6 +100,13 @@ fetch('/hamster.lottie')
     const speedValueSpan = document.getElementById('speed-value') as HTMLSpanElement;
     const destroyButton = document.getElementById('destroy') as HTMLButtonElement;
     const reloadButton = document.getElementById('reload') as HTMLButtonElement;
+    const jumpButton = document.getElementById('jump') as HTMLButtonElement;
+
+    jumpButton.addEventListener('click', () => {
+      const midFrame = dotLottie.totalFrames / 2;
+
+      dotLottie.setFrame(midFrame);
+    });
 
     destroyButton.addEventListener('click', () => {
       canvas.remove();

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -477,15 +477,17 @@ export class DotLottie {
     }
 
     if (!this._playing) {
-      // check if the animation has completed and is not currently playing
-      if (this._currentFrame >= this._totalFrames - 1 || this._currentFrame <= 0) {
-        this._beginTime = performance.now() / MS_TO_SEC_FACTOR;
-        this._elapsedTime = 0;
-        this._currentFrame = 0;
-      } else {
-        // animation is not complete, resume from the current position
-        this._beginTime = performance.now() / MS_TO_SEC_FACTOR - this._elapsedTime / this._speed;
+      // calculate the elapsed time based on the current frame and direction
+      const frameDuration = this._duration / this._totalFrames;
+      let frameTime = this._currentFrame * frameDuration;
+
+      // adjust frame time based on the current direction
+      if (this._mode === 'reverse' || (this._mode.includes('bounce') && this._direction === -1)) {
+        frameTime = this._duration - frameTime;
       }
+
+      // set the begin time based on the current frame position
+      this._beginTime = performance.now() / MS_TO_SEC_FACTOR - frameTime / this._speed;
 
       this._playing = true;
       this._eventManager.dispatch({
@@ -567,6 +569,20 @@ export class DotLottie {
     }
 
     this._currentFrame = frame;
+
+    // if the animation is playing, adjust the begin time to maintain continuity
+    if (this._playing) {
+      const frameDuration = this._duration / this._totalFrames;
+      let frameTime = frame * frameDuration;
+
+      // adjust frame time based on the current direction
+      if (this._mode === 'reverse' || (this._mode.includes('bounce') && this._direction === -1)) {
+        frameTime = this._duration - frameTime;
+      }
+
+      this._beginTime = performance.now() / MS_TO_SEC_FACTOR - frameTime / this._speed;
+    }
+
     this._renderer?.frame(this._currentFrame);
     this._render();
 

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -482,7 +482,7 @@ export class DotLottie {
       let frameTime = this._currentFrame * frameDuration;
 
       // adjust frame time based on the current direction
-      if (this._mode === 'reverse' || (this._mode.includes('bounce') && this._direction === -1)) {
+      if (this._direction === -1) {
         frameTime = this._duration - frameTime;
       }
 
@@ -576,7 +576,7 @@ export class DotLottie {
       let frameTime = frame * frameDuration;
 
       // adjust frame time based on the current direction
-      if (this._mode === 'reverse' || (this._mode.includes('bounce') && this._direction === -1)) {
+      if (this._direction === -1) {
         frameTime = this._duration - frameTime;
       }
 

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -477,7 +477,15 @@ export class DotLottie {
     }
 
     if (!this._playing) {
-      this._beginTime = performance.now() / MS_TO_SEC_FACTOR - this._elapsedTime / this._speed;
+      // check if the animation has completed and is not currently playing
+      if (this._currentFrame >= this._totalFrames - 1 || this._currentFrame <= 0) {
+        this._beginTime = performance.now() / MS_TO_SEC_FACTOR;
+        this._elapsedTime = 0;
+        this._currentFrame = 0;
+      } else {
+        // animation is not complete, resume from the current position
+        this._beginTime = performance.now() / MS_TO_SEC_FACTOR - this._elapsedTime / this._speed;
+      }
 
       this._playing = true;
       this._eventManager.dispatch({


### PR DESCRIPTION
## Description

This PR addresses few issues in the animation playback logic where animations were not resuming smoothly from their last progress point. Previously, when playback was paused and then resumed, the animation did not continue from the exact frame where it was interrupted. Instead, it either restarted from the beginning or exhibited frame jumps.

Changes:
Adjustment in `play` Method: Modified the logic to calculate the correct `_beginTime` based on the current `_elapsedTime` and `_speed`. This ensures that when the play method is called after a pause or stop, the animation resumes seamlessly from the exact point it was paused.

Refinement in `setSpeed` Method: Implemented a recalibration of `_beginTime` when the animation speed is adjusted during playback. This change prevents the animation frames from jumping or rewinding unexpectedly when the speed is changed, ensuring a smooth transition.

Update in `_update` Method: Included proper resetting of `_elapsedTime` at the end of each loop or bounce cycle. This adjustment ensures the continuity and smoothness of the animation, especially in looping, bounce, or bounce-reverse scenarios.

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
