### PR TITLE
feat: 🎸 freeze & unfreeze methods

### DIFF
--- a/.changeset/fluffy-trees-share.md
+++ b/.changeset/fluffy-trees-share.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': minor
+---
+
+feat: 🎸 add `freeze` & `unfreeze` methods

--- a/apps/dotlottie-web-example/src/main.ts
+++ b/apps/dotlottie-web-example/src/main.ts
@@ -45,6 +45,11 @@ app.innerHTML = `
       <label for="loopToggle">Loop: </label>
       <input type="checkbox" id="loopToggle" checked />
     </div>
+
+    <div>
+      <button id="freeze" class="control-button">Freeze</button>
+      <button id="unfreeze" class="control-button">Unfreeze</button>
+    </div>
     
     <label for="frameSlider">Frame: <span id="current-frame">0</span></label>
     <input type="range" id="frameSlider" min="0" step="0.1" />
@@ -128,6 +133,16 @@ fetch('/hamster.lottie')
     const startFrameInput = document.getElementById('startFrame') as HTMLInputElement;
     const endFrameInput = document.getElementById('endFrame') as HTMLInputElement;
     const setSegmentsButton = document.getElementById('setSegments') as HTMLButtonElement;
+    const freezeButton = document.getElementById('freeze') as HTMLButtonElement;
+    const unfreezeButton = document.getElementById('unfreeze') as HTMLButtonElement;
+
+    freezeButton.addEventListener('click', () => {
+      dotLottie.freeze();
+    });
+
+    unfreezeButton.addEventListener('click', () => {
+      dotLottie.unfreeze();
+    });
 
     setSegmentsButton.addEventListener('click', () => {
       const startFrame = parseInt(startFrameInput.value, 10);

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -173,6 +173,8 @@ The `DotLottie` constructor accepts a config object with the following propertie
 | `load(config: Config)`                                    | Loads a new configuration or a new animation.                                                                                                                     |
 | `setMode(mode: string)`                                   | Sets the animation play mode.                                                                                                                                     |
 | `setSegments(startFrame: number, endFrame: number)`       | Sets the start and end frame of the animation.                                                                                                                    |
+| `freeze()`                                                | Freezes the animation by stopping the animation loop.                                                                                                             |
+| `unfreeze()`                                              | Unfreezes the animation by resuming the animation loop.                                                                                                           |
 
 ### Static Methods
 

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -832,5 +832,22 @@ export class DotLottie {
     this._playbackState = 'stopped';
   }
 
+  /**
+   * Freezes the animation by stopping the animation loop.
+   *
+   */
+  public freeze(): void {
+    this._stopAnimationLoop();
+  }
+
+  /**
+   * Unfreezes the animation by resuming the animation loop.
+   *
+   */
+  public unfreeze(): void {
+    this._synchronizeAnimationTiming(this._currentFrame);
+    this._startAnimationLoop();
+  }
+
   // #endregion
 }

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -463,7 +463,7 @@ export class DotLottie {
    * Adjusts the canvas size based on the device pixel ratio and the size of the canvas element.
    *
    */
-  public _resizeAnimationToCanvas(): void {
+  private _resizeAnimationToCanvas(): void {
     if (!this._shouldAutoResizeCanvas) return;
 
     const clientRects = this._canvas.getClientRects();
@@ -491,7 +491,7 @@ export class DotLottie {
    *
    * This is used to ensure that the animation loop is only stopped once.
    */
-  public _stopAnimationLoop(): void {
+  private _stopAnimationLoop(): void {
     if (this._animationFrameId) {
       window.cancelAnimationFrame(this._animationFrameId);
     }
@@ -502,26 +502,26 @@ export class DotLottie {
    *
    * This is used to ensure that the animation loop is only started once.
    */
-  public _startAnimationLoop(): void {
+  private _startAnimationLoop(): void {
     if (this._animationFrameId) {
       window.cancelAnimationFrame(this._animationFrameId);
     }
     this._animationFrameId = window.requestAnimationFrame(this._animationLoop);
   }
 
-  public _getEffectiveStartFrame(): number {
+  private _getEffectiveStartFrame(): number {
     return this._segments ? this._segments[0] : 0;
   }
 
-  public _getEffectiveEndFrame(): number {
+  private _getEffectiveEndFrame(): number {
     return this._segments ? this._segments[1] : this._totalFrames - 1;
   }
 
-  public _getEffectiveTotalFrames(): number {
+  private _getEffectiveTotalFrames(): number {
     return this._segments ? this._segments[1] - this._segments[0] : this._totalFrames;
   }
 
-  public _getEffectiveDuration(): number {
+  private _getEffectiveDuration(): number {
     return this._segments
       ? this._duration * ((this._segments[1] - this._segments[0]) / this._totalFrames)
       : this._duration;

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -861,7 +861,8 @@ export class DotLottie {
     this._startAnimationLoop();
   }
 
-  /**  Sets the background color of the canvas.
+  /**
+   * Sets the background color of the canvas.
    *
    * @param color - The background color of the canvas.
    */


### PR DESCRIPTION
## Description

 introduces two new methods, `freeze` and `unfreeze`, to the `DotLottie` class. These methods enhance the control over animation playback by allowing animations to be temporarily halted and resumed without altering their current state or frame.

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
