### PR TITLE
perf: ⚡️ skip re-allocating new ImageData & Uint8ClampedArray for each frame

### DIFF
--- a/.changeset/lazy-items-play.md
+++ b/.changeset/lazy-items-play.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+perf: ⚡️ skip re-allocating new ImageData & Uint8ClampedArray for each frame

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -147,6 +147,8 @@ export class DotLottie {
 
   private _useFrameInterpolation = true;
 
+  private _imageData: ImageData | null = null;
+
   public constructor(config: Config) {
     this._animationLoop = this._animationLoop.bind(this);
 
@@ -424,19 +426,13 @@ export class DotLottie {
     if (this._renderer.update()) {
       const buffer = this._renderer.render();
 
-      if (buffer.length === 0) {
-        console.warn('Empty buffer received from renderer.');
-
-        return;
+      if (this._imageData?.data.length !== buffer.length) {
+        this._imageData = this._context.createImageData(width, height);
       }
 
-      const clampedBuffer = new Uint8ClampedArray(buffer);
+      this._imageData.data.set(buffer);
 
-      const imageData = this._context.createImageData(width, height);
-
-      imageData.data.set(clampedBuffer);
-
-      this._context.putImageData(imageData, 0, 0);
+      this._context.putImageData(this._imageData, 0, 0);
     }
   }
 

--- a/packages/web/src/wasm/index.ts
+++ b/packages/web/src/wasm/index.ts
@@ -10,7 +10,7 @@ export interface Renderer {
   error(): string;
   frame(no: number): boolean;
   load(data: string, width: number, height: number): boolean;
-  render(): Uint8Array;
+  render(): Uint8ClampedArray;
   resize(width: number, height: number): void;
   setBgColor(color: number): void;
   size(): Float32Array;


### PR DESCRIPTION
## Description

* Now only creates a new ImageData when the buffer size changes, reusing the previous ImageData to avoid unnecessary allocations.
* The ThorVG buffer is guaranteed to be an 8-bit unsigned integer ranging from 0 to 255, so there is no need to allocate a new Uint8ClampedArray for casting, as the values won't exceed 255 or fall below 0.

After
<img width="682" alt="Screenshot 2024-01-02 at 12 35 25 PM" src="https://github.com/LottieFiles/dotlottie-web/assets/39750790/80c54078-9145-4a29-b7f5-5880f1d2f52d">

Before
<img width="657" alt="Screenshot 2024-01-02 at 12 34 09 PM" src="https://github.com/LottieFiles/dotlottie-web/assets/39750790/a7d0fe90-84cd-44d7-935a-97366c705b45">

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
