### PR TITLE
fix: 🐛 load animation url with response content-type of text/plain

### DIFF
--- a/.changeset/spotty-forks-battle.md
+++ b/.changeset/spotty-forks-battle.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+fix: 🐛 load animation url with response content-type of text/plain

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -30,7 +30,7 @@ export async function loadAnimationJSONFromURL(animationURL: string): Promise<st
     const contentType = response.headers.get('content-type');
     let animationJSON: string;
 
-    if (contentType?.includes('application/json')) {
+    if (contentType?.includes('application/json') || contentType?.includes('text/plain')) {
       animationJSON = await response.text();
     } else {
       const arrayBuffer = await response.arrayBuffer();


### PR DESCRIPTION
## Description

if the content-type of the provided url is either a json or plain text, assume it's for a lottie json and let the renderer try to load it, if it fails to load then a loadError event would be emitted

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
