### PR TITLE
fix: 🐛 improve content-type parsing when loading from a url

### DIFF
--- a/.changeset/thick-pumas-stare.md
+++ b/.changeset/thick-pumas-stare.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+fix: 🐛 improve content-type parsing when loading from a url

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -190,11 +190,11 @@ export class DotLottie {
         );
       }
 
-      const contentType = response.headers.get('content-type');
+      const contentType = (response.headers.get('content-type') ?? '').trim();
 
       let data: string | ArrayBuffer;
 
-      if (['application/json', 'text/plain'].includes(contentType ?? '')) {
+      if (['application/json', 'text/plain'].some((type) => contentType.startsWith(type))) {
         data = await response.text();
       } else {
         data = await response.arrayBuffer();


### PR DESCRIPTION
## Description

Issue:
- Unable to load from url if the response's content-type contains anything more than `media-type`.
- For example, `text/plain` works but `text/plain; charset=utf-8` doesn't.
- [Test File](https://raw.githubusercontent.com/thorvg/thorvg/main/examples/resources/lottie/seawalk.json)

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
