### PR TITLE
ci: 🎡 fix dual publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,11 +58,13 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  release:
-    name: release
+  npm-release:
+    name: npm-release
     needs: validate
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'LottieFiles/dotlottie-web' && github.event_name == 'push' }}
+    if:
+      github.event_name == 'pull_request' && github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
@@ -107,6 +109,26 @@ jobs:
 
       - name: Remove existing NPM .npmrc
         run: rm -f "$HOME/.npmrc"
+
+  gpr-release:
+    name: gpr-release
+    needs: [validate, npm-release]
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'pull_request' && github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'changeset-release/main'
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+        with:
+          # https://github.com/changesets/action/issues/201#issuecomment-1206088289
+          # check out all commits and tags so changeset can skip duplicate tags
+          fetch-depth: 0
+
+      - name: ⎔ Setup pnpm@v8
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
 
       - name: ⎔ Setup Node@v18 for Github Packages
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Description

To ensure both npm and gpr releases are done right after the update versions PR is merged to main