### PR TITLE
feat(react): 🎸 optimize animation playback based on initial visibility

### DIFF
--- a/.changeset/smart-garlics-approve.md
+++ b/.changeset/smart-garlics-approve.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-react': minor
+---
+
+feat(react): 🎸 optimize animation playback based on initial visibility

--- a/apps/dotlottie-react-example/src/App.tsx
+++ b/apps/dotlottie-react-example/src/App.tsx
@@ -22,6 +22,7 @@ function App() {
 
   React.useEffect(() => {
     function updateCurrentFrame(event: { currentFrame: number }) {
+      console.log('currentFrame', event.currentFrame);
       setCurrentFrame(event.currentFrame);
     }
 
@@ -32,6 +33,8 @@ function App() {
     }
 
     dotLottie?.addEventListener('play', console.log);
+    dotLottie?.addEventListener('freeze', console.log);
+    dotLottie?.addEventListener('unfreeze', console.log);
     dotLottie?.addEventListener('pause', console.log);
     dotLottie?.addEventListener('stop', console.log);
     dotLottie?.addEventListener('load', onLoad);
@@ -39,6 +42,8 @@ function App() {
 
     return () => {
       dotLottie?.removeEventListener('play', console.log);
+      dotLottie?.removeEventListener('freeze', console.log);
+      dotLottie?.removeEventListener('unfreeze', console.log);
       dotLottie?.addEventListener('pause', console.log);
       dotLottie?.addEventListener('stop', console.log);
       dotLottie?.removeEventListener('load', onLoad);
@@ -49,7 +54,12 @@ function App() {
   const progress = dotLottie?.isLoaded ? (currentFrame / dotLottie.totalFrames) * 100 : 0;
 
   return (
-    <>
+    <div>
+      <div
+        style={{
+          marginBottom: '1000px',
+        }}
+      ></div>
       <DotLottieReact
         dotLottieRefCallback={setDotLottie}
         useFrameInterpolation={useFrameInterpolation}
@@ -152,7 +162,7 @@ function App() {
         }}
       />
       Auto resize canvas
-    </>
+    </div>
   );
 }
 

--- a/packages/react/src/use-dotlottie.tsx
+++ b/packages/react/src/use-dotlottie.tsx
@@ -115,6 +115,20 @@ export const useDotLottie = (config?: DotLottieConfig): UseDotLottieResult => {
 
         setDotLottie(dotLottieInstance);
 
+        // Check if the canvas is initially in view
+        const initialEntry = canvas.getBoundingClientRect();
+
+        if (
+          initialEntry.top >= 0 &&
+          initialEntry.left >= 0 &&
+          initialEntry.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+          initialEntry.right <= (window.innerWidth || document.documentElement.clientWidth)
+        ) {
+          dotLottieInstance.unfreeze();
+        } else {
+          dotLottieInstance.freeze();
+        }
+
         intersectionObserver.observe(canvas);
         if (config?.autoResizeCanvas) {
           resizeObserver.observe(canvas);


### PR DESCRIPTION
This pull request optimizes the DotLottieReact component by ensuring that the animation only starts playing when the canvas is within the viewport initially. If the canvas is outside the viewport, the animation will remain frozen until it becomes visible.

Changes:
- Added logic to check if the canvas is initially within the viewport using `getBoundingClientRect()`