### PR TITLE
fix(svelte): disable runes in components

### DIFF
--- a/.changeset/wicked-starfishes-shop.md
+++ b/.changeset/wicked-starfishes-shop.md
@@ -1,5 +1,5 @@
 ---
-'@lottiefiles/dotlottie-svelte': major
+'@lottiefiles/dotlottie-svelte': minor
 ---
 
 fix(svelte): disable runes in component to prevent compiler issue on runes mode

--- a/.changeset/wicked-starfishes-shop.md
+++ b/.changeset/wicked-starfishes-shop.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-svelte': major
+---
+
+fix(svelte): disable runes in component to prevent compiler issue on runes mode

--- a/packages/svelte/src/lib/Dotlottie.svelte
+++ b/packages/svelte/src/lib/Dotlottie.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={false} />
+
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import debounce from 'debounce';

--- a/packages/svelte/src/routes/+page.svelte
+++ b/packages/svelte/src/routes/+page.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes={false} />
+
 <script lang="ts">
 	import { DotLottieSvelte, setWasmUrl } from '../lib/index.js';
 	import type { DotLottie } from '../lib/index.js';

--- a/packages/svelte/src/routes/+page.svelte
+++ b/packages/svelte/src/routes/+page.svelte
@@ -1,5 +1,3 @@
-<svelte:options runes={false} />
-
 <script lang="ts">
 	import { DotLottieSvelte, setWasmUrl } from '../lib/index.js';
 	import type { DotLottie } from '../lib/index.js';


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->
Disable runes in svelte components to prevent compiler issues when running on runes mode.
Fixes #216 

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [X] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
