### PR TITLE
fix(react): 🐛 "Worker is not defined" error in Next.js SSR

### DIFF
--- a/.changeset/witty-jobs-kick.md
+++ b/.changeset/witty-jobs-kick.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-react': patch
+---
+
+fix(react): 🐛 "Worker is not defined" error in Next.js SSR

--- a/packages/react/src/dotlottie.tsx
+++ b/packages/react/src/dotlottie.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { DotLottie, Config } from '@lottiefiles/dotlottie-web';
 import type { ComponentProps, RefCallback } from 'react';
 import React from 'react';


### PR DESCRIPTION
Changes: 

- Added `use client` directive to DotLottieReact component module to mark it as a client only component

✅ Closes: #311