### PR TITLE
chore(web|react): update build target from ES2020 to ES2015

### DIFF
--- a/.changeset/shaggy-cups-cross.md
+++ b/.changeset/shaggy-cups-cross.md
@@ -1,0 +1,6 @@
+---
+'@lottiefiles/dotlottie-react': minor
+'@lottiefiles/dotlottie-web': minor
+---
+
+chore(web|react): update build target from ES2020 to ES2015

--- a/.changeset/shaggy-cups-cross.md
+++ b/.changeset/shaggy-cups-cross.md
@@ -3,4 +3,4 @@
 '@lottiefiles/dotlottie-web': minor
 ---
 
-chore(web|react): update build target from ES2020 to ES2015
+chore: update build target from ES2020 to ES2015

--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "@lottiefiles/dotlottie-web-monorepo",
   "license": "MIT",
   "private": true,
-  "workspaces": [
-    "apps/*",
-    "packages/*"
-  ],
   "scripts": {
     "build": "turbo run build",
     "changelog": "changeset add",

--- a/packages/react/tsup.config.cjs
+++ b/packages/react/tsup.config.cjs
@@ -12,7 +12,7 @@ module.exports = defineConfig({
   entry: ['./src/index.ts'],
   format: ['esm'],
   platform: 'browser',
-  target: ['es2020', 'node18'],
+  target: ['es2015', 'node18'],
   tsconfig: 'tsconfig.build.json',
   // To provide an esm build without any external dependencies
   noExternal: Object.keys(require('./package.json').dependencies),

--- a/packages/web/tsup.config.cjs
+++ b/packages/web/tsup.config.cjs
@@ -32,7 +32,7 @@ module.exports = defineConfig({
   outDir: './dist',
   format: ['esm', 'cjs'],
   platform: 'neutral',
-  target: ['es2020', 'node18'],
+  target: ['es2015', 'node18'],
   tsconfig: 'tsconfig.build.json',
   esbuildPlugins: [
     // This plugin is used to inline the workers as base64 strings in the output bundle


### PR DESCRIPTION
Changes:
- Build dotlottie-web and dotlottie-react for ES2015 instead of ES2020.
- This resolves issues on platforms that don't support ES2020 by default, ensuring compatibility with ES6.
- Added a babel example to illustrate cases where ES2020 features, such as optional chaining, are not supported.