### PR TITLE
chore(react): update JSX transform to "react-jsx" and drop React 16 support

### DIFF
--- a/.changeset/mean-dolls-brush.md
+++ b/.changeset/mean-dolls-brush.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-react': minor
+---
+
+chore(react): update JSX transform to "react-jsx" and drop React 16 support

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: 🛡️ Test
         run: |
-          npx playwright install --with-deps
+          npx playwright install --with-deps chromium
           pnpm test:coverage
         working-directory: packages/web
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,18 +41,15 @@
     "type-check": "tsc --noEmit"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^17 || ^18"
   },
   "dependencies": {
     "@lottiefiles/dotlottie-web": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.2.37",
-    "@types/react-dom": "^18.2.15",
     "cross-env": "7.0.3",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "tsup": "8.0.1",
     "typescript": "5.0.4"
   },

--- a/packages/react/src/dotlottie-worker.tsx
+++ b/packages/react/src/dotlottie-worker.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import type { DotLottieWorker, Config } from '@lottiefiles/dotlottie-web';
-import type { ComponentProps, RefCallback } from 'react';
-import React from 'react';
+import { useEffect, type ComponentProps, type RefCallback } from 'react';
 
 import { useDotLottieWorker } from './use-dotlottie-worker';
 import useStableCallback from './use-stable-callback';
@@ -59,7 +58,7 @@ export const DotLottieWorkerReact = ({
   const stableDotLottieRefCallback =
     typeof dotLottieRefCallback === 'function' ? useStableCallback(dotLottieRefCallback) : undefined;
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (typeof stableDotLottieRefCallback === 'function') {
       stableDotLottieRefCallback(dotLottie);
     }

--- a/packages/react/src/dotlottie.tsx
+++ b/packages/react/src/dotlottie.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import type { DotLottie, Config } from '@lottiefiles/dotlottie-web';
-import type { ComponentProps, RefCallback } from 'react';
-import React from 'react';
+import { useEffect, type ComponentProps, type RefCallback } from 'react';
 
 import { useDotLottie } from './use-dotlottie';
 import useStableCallback from './use-stable-callback';
@@ -56,7 +55,7 @@ export const DotLottieReact = ({
   const stableDotLottieRefCallback =
     typeof dotLottieRefCallback === 'function' ? useStableCallback(dotLottieRefCallback) : undefined;
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (typeof stableDotLottieRefCallback === 'function') {
       stableDotLottieRefCallback(dotLottie);
     }

--- a/packages/react/src/use-dotlottie-worker.tsx
+++ b/packages/react/src/use-dotlottie-worker.tsx
@@ -1,6 +1,6 @@
 import type { Config } from '@lottiefiles/dotlottie-web';
 import { DotLottieWorker } from '@lottiefiles/dotlottie-web';
-import React, { useCallback, useState, useEffect, useRef } from 'react';
+import { useCallback, useState, useEffect, useRef } from 'react';
 import type { ComponentProps, RefCallback } from 'react';
 
 interface DotLottieWorkerComponentProps {

--- a/packages/react/src/use-dotlottie.tsx
+++ b/packages/react/src/use-dotlottie.tsx
@@ -1,6 +1,6 @@
 import type { Config } from '@lottiefiles/dotlottie-web';
 import { DotLottie } from '@lottiefiles/dotlottie-web';
-import React, { useCallback, useState, useEffect, useRef } from 'react';
+import { useCallback, useState, useEffect, useRef } from 'react';
 import type { ComponentProps, RefCallback } from 'react';
 
 interface DotLottieComponentProps {

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -10,7 +10,7 @@
     // Source root directory
     "rootDir": ".",
 
-    "jsx": "react",
+    "jsx": "react-jsx",
 
     "exactOptionalPropertyTypes": false
   },

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -4,7 +4,7 @@
 
   // Compiler options
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "exactOptionalPropertyTypes": false
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
         version: 2.27.5
       '@commitlint/cli':
         specifier: 17.6.1
-        version: 17.6.1(@swc/core@1.3.107)
+        version: 17.6.1(@swc/core@1.3.107(@swc/helpers@0.5.5))
       '@lottiefiles/commitlint-config':
         specifier: 2.0.0
-        version: 2.0.0(@commitlint/cli@17.6.1(@swc/core@1.3.107))
+        version: 2.0.0(@commitlint/cli@17.6.1(@swc/core@1.3.107(@swc/helpers@0.5.5)))
       '@lottiefiles/eslint-plugin':
         specifier: 3.0.0
         version: 3.0.0(@types/node@20.5.1)(encoding@0.1.13)(eslint@7.32.0)(graphql@16.8.1)(prettier@2.8.8)(typescript@5.0.4)
@@ -31,7 +31,7 @@ importers:
         version: 2.0.0(typescript@5.0.4)
       '@size-limit/preset-big-lib':
         specifier: ^11.1.4
-        version: 11.1.4(@swc/core@1.3.107)(size-limit@11.1.4)
+        version: 11.1.4(@swc/core@1.3.107(@swc/helpers@0.5.5))(size-limit@11.1.4)
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
@@ -235,7 +235,7 @@ importers:
         version: 10.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.3(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2))
+        version: 3.4.3(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2))
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
@@ -393,21 +393,15 @@ importers:
       '@types/react':
         specifier: ^18.2.37
         version: 18.2.43
-      '@types/react-dom':
-        specifier: ^18.2.15
-        version: 18.2.17
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
       react:
         specifier: ^18.2.0
         version: 18.2.0
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
       tsup:
         specifier: 8.0.1
-        version: 8.0.1(@swc/core@1.3.107)(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.0.4))(typescript@5.0.4)
+        version: 8.0.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.0.4))(typescript@5.0.4)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -426,10 +420,10 @@ importers:
         version: 1.8.17
       tsup:
         specifier: ^8.0.2
-        version: 8.1.0(@swc/core@1.3.107)(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5)
+        version: 8.1.0(@swc/core@1.3.107(@swc/helpers@0.5.5))(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.21.5)(solid-js@1.8.17)(tsup@8.1.0(@swc/core@1.3.107)(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5))
+        version: 2.2.0(esbuild@0.21.5)(solid-js@1.8.17)(tsup@8.1.0(@swc/core@1.3.107(@swc/helpers@0.5.5))(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5))
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -469,7 +463,7 @@ importers:
         version: 9.1.0(eslint@8.56.0)
       eslint-plugin-svelte:
         specifier: ^2.36.0-next.4
-        version: 2.36.0-next.5(eslint@8.56.0)(svelte@5.0.0-next.55)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2))
+        version: 2.36.0-next.5(eslint@8.56.0)(svelte@5.0.0-next.55)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2))
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -484,7 +478,7 @@ importers:
         version: 5.0.0-next.55
       svelte-check:
         specifier: ^3.6.0
-        version: 3.6.4(@babel/core@7.24.9)(postcss-load-config@4.0.2(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2)))(postcss@8.4.32)(svelte@5.0.0-next.55)
+        version: 3.6.4(@babel/core@7.24.9)(postcss-load-config@4.0.2(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2)))(postcss@8.4.32)(svelte@5.0.0-next.55)
       tslib:
         specifier: ^2.4.1
         version: 2.6.2
@@ -518,7 +512,7 @@ importers:
         version: 7.0.3
       tsup:
         specifier: 8.0.1
-        version: 8.0.1(@swc/core@1.3.107)(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.0.4))(typescript@5.0.4)
+        version: 8.0.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.0.4))(typescript@5.0.4)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -537,7 +531,7 @@ importers:
         version: 7.0.3
       tsup:
         specifier: 8.0.1
-        version: 8.0.1(@swc/core@1.3.107)(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.0.4))(typescript@5.0.4)
+        version: 8.0.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.0.4))(typescript@5.0.4)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -567,7 +561,7 @@ importers:
         version: 1.45.2
       tsup:
         specifier: 8.2.0
-        version: 8.2.0(@swc/core@1.3.107)(jiti@1.21.0)(postcss@8.4.39)(typescript@5.0.4)(yaml@2.4.5)
+        version: 8.2.0(@swc/core@1.3.107(@swc/helpers@0.5.5))(jiti@1.21.0)(postcss@8.4.39)(typescript@5.0.4)(yaml@2.4.5)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -8329,7 +8323,7 @@ packages:
   puppeteer@21.4.1:
     resolution: {integrity: sha512-opJqQeYMjAB3ICG8lCF3wtSs9k05dozmrEMrHgo3ZWbISiy8qbv/yAJz/6Io221qSh3yURfVf6Z7crrlzKZjLQ==}
     engines: {node: '>=16.3.0'}
-    deprecated: < 22.6.4 is no longer supported
+    deprecated: < 22.8.2 is no longer supported
 
   pvtsutils@1.3.5:
     resolution: {integrity: sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==}
@@ -11208,11 +11202,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@17.6.1(@swc/core@1.3.107)':
+  '@commitlint/cli@17.6.1(@swc/core@1.3.107(@swc/helpers@0.5.5))':
     dependencies:
       '@commitlint/format': 17.8.1
       '@commitlint/lint': 17.8.1
-      '@commitlint/load': 17.8.1(@swc/core@1.3.107)
+      '@commitlint/load': 17.8.1(@swc/core@1.3.107(@swc/helpers@0.5.5))
       '@commitlint/read': 17.8.1
       '@commitlint/types': 17.8.1
       execa: 5.1.1
@@ -11261,7 +11255,7 @@ snapshots:
       '@commitlint/rules': 17.8.1
       '@commitlint/types': 17.8.1
 
-  '@commitlint/load@17.8.1(@swc/core@1.3.107)':
+  '@commitlint/load@17.8.1(@swc/core@1.3.107(@swc/helpers@0.5.5))':
     dependencies:
       '@commitlint/config-validator': 17.8.1
       '@commitlint/execute-rule': 17.8.1
@@ -11270,12 +11264,12 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.4.5)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.5))(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.5))(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.0.4)
+      ts-node: 10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.5.1)(typescript@5.0.4)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@swc/core'
@@ -12102,9 +12096,9 @@ snapshots:
   '@lmdb/lmdb-win32-x64@2.8.5':
     optional: true
 
-  '@lottiefiles/commitlint-config@2.0.0(@commitlint/cli@17.6.1(@swc/core@1.3.107))':
+  '@lottiefiles/commitlint-config@2.0.0(@commitlint/cli@17.6.1(@swc/core@1.3.107(@swc/helpers@0.5.5)))':
     dependencies:
-      '@commitlint/cli': 17.6.1(@swc/core@1.3.107)
+      '@commitlint/cli': 17.6.1(@swc/core@1.3.107(@swc/helpers@0.5.5))
       '@commitlint/config-conventional': 16.2.1
 
   '@lottiefiles/eslint-plugin@3.0.0(@types/node@20.5.1)(encoding@0.1.13)(eslint@7.32.0)(graphql@16.8.1)(prettier@2.8.8)(typescript@5.0.4)':
@@ -12433,13 +12427,15 @@ snapshots:
     transitivePeerDependencies:
       - '@parcel/core'
 
-  '@parcel/cache@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))':
+  '@parcel/cache@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)':
     dependencies:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.5)
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
       '@parcel/logger': 2.12.0
       '@parcel/utils': 2.12.0
       lmdb: 2.8.5
+    transitivePeerDependencies:
+      - '@swc/helpers'
 
   '@parcel/codeframe@2.12.0':
     dependencies:
@@ -12499,7 +12495,7 @@ snapshots:
   '@parcel/core@2.12.0(@swc/helpers@0.5.5)':
     dependencies:
       '@mischnic/json-sourcemap': 0.1.1
-      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))
+      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
       '@parcel/diagnostic': 2.12.0
       '@parcel/events': 2.12.0
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
@@ -12512,7 +12508,7 @@ snapshots:
       '@parcel/source-map': 2.1.1
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))
       abortcontroller-polyfill: 1.7.5
       base-x: 3.0.10
       browserslist: 4.23.2
@@ -12540,7 +12536,7 @@ snapshots:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
       '@parcel/utils': 2.12.0
       '@parcel/watcher': 2.4.1
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -12614,7 +12610,7 @@ snapshots:
       '@parcel/plugin': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))
       '@parcel/rust': 2.12.0
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))
 
   '@parcel/optimizer-svgo@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))':
     dependencies:
@@ -12646,7 +12642,7 @@ snapshots:
       '@parcel/node-resolver-core': 3.3.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))
       '@swc/core': 1.3.107(@swc/helpers@0.5.5)
       semver: 7.6.3
     transitivePeerDependencies:
@@ -12835,7 +12831,7 @@ snapshots:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.5)
       '@parcel/plugin': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))
       nullthrows: 1.1.1
 
   '@parcel/transformer-js@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))':
@@ -12846,7 +12842,7 @@ snapshots:
       '@parcel/rust': 2.12.0
       '@parcel/source-map': 2.1.1
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))
       '@swc/helpers': 0.5.5
       browserslist: 4.23.2
       nullthrows: 1.1.1
@@ -12914,12 +12910,12 @@ snapshots:
 
   '@parcel/types@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)':
     dependencies:
-      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))
+      '@parcel/cache': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
       '@parcel/diagnostic': 2.12.0
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
       '@parcel/package-manager': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
       '@parcel/source-map': 2.1.1
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))
       utility-types: 3.11.0
     transitivePeerDependencies:
       - '@parcel/core'
@@ -12992,7 +12988,7 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.4.1
       '@parcel/watcher-win32-x64': 2.4.1
 
-  '@parcel/workers@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)':
+  '@parcel/workers@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))':
     dependencies:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.5)
       '@parcel/diagnostic': 2.12.0
@@ -13001,8 +12997,6 @@ snapshots:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.5))(@swc/helpers@0.5.5)
       '@parcel/utils': 2.12.0
       nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - '@swc/helpers'
 
   '@peculiar/asn1-schema@2.3.8':
     dependencies:
@@ -13061,6 +13055,21 @@ snapshots:
       yargs: 17.7.1
     optionalDependencies:
       typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@puppeteer/browsers@1.4.6(typescript@5.2.2)':
+    dependencies:
+      debug: 4.3.4
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.3.0
+      tar-fs: 3.0.4
+      unbzip2-stream: 1.4.3
+      yargs: 17.7.1
+    optionalDependencies:
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -13314,11 +13323,11 @@ snapshots:
     dependencies:
       size-limit: 11.1.4
 
-  '@size-limit/preset-big-lib@11.1.4(@swc/core@1.3.107)(size-limit@11.1.4)':
+  '@size-limit/preset-big-lib@11.1.4(@swc/core@1.3.107(@swc/helpers@0.5.5))(size-limit@11.1.4)':
     dependencies:
       '@size-limit/file': 11.1.4(size-limit@11.1.4)
       '@size-limit/time': 11.1.4(size-limit@11.1.4)
-      '@size-limit/webpack': 11.1.4(@swc/core@1.3.107)(size-limit@11.1.4)
+      '@size-limit/webpack': 11.1.4(@swc/core@1.3.107(@swc/helpers@0.5.5))(size-limit@11.1.4)
       size-limit: 11.1.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -13338,11 +13347,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@size-limit/webpack@11.1.4(@swc/core@1.3.107)(size-limit@11.1.4)':
+  '@size-limit/webpack@11.1.4(@swc/core@1.3.107(@swc/helpers@0.5.5))(size-limit@11.1.4)':
     dependencies:
       nanoid: 5.0.7
       size-limit: 11.1.4
-      webpack: 5.92.1(@swc/core@1.3.107)
+      webpack: 5.92.1(@swc/core@1.3.107(@swc/helpers@0.5.5))
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -14154,12 +14163,15 @@ snapshots:
       vite: 5.0.13(@types/node@20.14.11)(lightningcss@1.26.0)(terser@5.31.1)
       vue: 3.4.6(typescript@5.2.2)
 
-  '@vitest/browser@1.6.0(vitest@1.2.2)':
+  '@vitest/browser@1.6.0(playwright@1.45.2)(vitest@1.2.2)(webdriverio@8.39.1(encoding@0.1.13)(typescript@5.2.2))':
     dependencies:
       '@vitest/utils': 1.6.0
       magic-string: 0.30.10
       sirv: 2.0.4
       vitest: 1.2.2(@types/node@20.14.11)(@vitest/browser@1.6.0)(lightningcss@1.26.0)(terser@5.31.1)
+    optionalDependencies:
+      playwright: 1.45.2
+      webdriverio: 8.39.1(encoding@0.1.13)(typescript@5.2.2)
     optional: true
 
   '@vitest/browser@2.0.3(playwright@1.45.2)(typescript@5.0.4)(vitest@2.0.3)(webdriverio@8.39.1(encoding@0.1.13)(typescript@5.0.4))':
@@ -15338,11 +15350,11 @@ snapshots:
     dependencies:
       '@iarna/toml': 2.2.5
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.5))(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.5))(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.4.5)
-      ts-node: 10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.0.4)
+      ts-node: 10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.5.1)(typescript@5.0.4)
       typescript: 5.4.5
 
   cosmiconfig@7.0.1:
@@ -16516,7 +16528,7 @@ snapshots:
       eslint: 7.32.0
       natural-compare-lite: 1.4.0
 
-  eslint-plugin-svelte@2.36.0-next.5(eslint@8.56.0)(svelte@5.0.0-next.55)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2)):
+  eslint-plugin-svelte@2.36.0-next.5(eslint@8.56.0)(svelte@5.0.0-next.55)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2)):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -16526,7 +16538,7 @@ snapshots:
       esutils: 2.0.3
       known-css-properties: 0.29.0
       postcss: 8.4.32
-      postcss-load-config: 3.1.4(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2))
+      postcss-load-config: 3.1.4(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2))
       postcss-safe-parser: 6.0.0(postcss@8.4.32)
       postcss-selector-parser: 6.0.15
       semver: 7.5.4
@@ -19771,46 +19783,46 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.32
 
-  postcss-load-config@3.1.4(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2)):
+  postcss-load-config@3.1.4(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.4.32
-      ts-node: 10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2)
+      ts-node: 10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2)
 
-  postcss-load-config@4.0.1(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2)):
+  postcss-load-config@4.0.1(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 2.3.3
     optionalDependencies:
       postcss: 8.4.32
-      ts-node: 10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2)
+      ts-node: 10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2)
 
-  postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.0.4)):
+  postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.0.4)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 2.3.3
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.0.4)
+      ts-node: 10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.0.4)
 
-  postcss-load-config@4.0.2(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2)):
+  postcss-load-config@4.0.2(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.32
-      ts-node: 10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2)
+      ts-node: 10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2)
     optional: true
 
-  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.4.5)):
+  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.4.5)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.39
-      ts-node: 10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.4.5)
+      ts-node: 10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.4.5)
 
   postcss-load-config@6.0.1(jiti@1.21.0)(postcss@8.4.39)(yaml@2.4.5):
     dependencies:
@@ -20051,6 +20063,23 @@ snapshots:
       ws: 8.13.0
     optionalDependencies:
       typescript: 5.0.4
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    optional: true
+
+  puppeteer-core@20.9.0(encoding@0.1.13)(typescript@5.2.2):
+    dependencies:
+      '@puppeteer/browsers': 1.4.6(typescript@5.2.2)
+      chromium-bidi: 0.4.16(devtools-protocol@0.0.1147663)
+      cross-fetch: 4.0.0(encoding@0.1.13)
+      debug: 4.3.4
+      devtools-protocol: 0.0.1147663
+      ws: 8.13.0
+    optionalDependencies:
+      typescript: 5.2.2
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -21525,7 +21554,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@3.6.4(@babel/core@7.24.9)(postcss-load-config@4.0.2(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2)))(postcss@8.4.32)(svelte@5.0.0-next.55):
+  svelte-check@3.6.4(@babel/core@7.24.9)(postcss-load-config@4.0.2(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2)))(postcss@8.4.32)(svelte@5.0.0-next.55):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.20
       chokidar: 3.5.3
@@ -21534,7 +21563,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 5.0.0-next.55
-      svelte-preprocess: 5.1.3(@babel/core@7.24.9)(postcss-load-config@4.0.2(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2)))(postcss@8.4.32)(svelte@5.0.0-next.55)(typescript@5.4.5)
+      svelte-preprocess: 5.1.3(@babel/core@7.24.9)(postcss-load-config@4.0.2(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2)))(postcss@8.4.32)(svelte@5.0.0-next.55)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -21574,7 +21603,7 @@ snapshots:
       svelte-dev-helper: 1.1.9
       svelte-hmr: 0.14.12(svelte@5.0.0-next.55)
 
-  svelte-preprocess@5.1.3(@babel/core@7.24.9)(postcss-load-config@4.0.2(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2)))(postcss@8.4.32)(svelte@5.0.0-next.55)(typescript@5.4.5):
+  svelte-preprocess@5.1.3(@babel/core@7.24.9)(postcss-load-config@4.0.2(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2)))(postcss@8.4.32)(svelte@5.0.0-next.55)(typescript@5.4.5):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
@@ -21585,7 +21614,7 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.24.9
       postcss: 8.4.32
-      postcss-load-config: 4.0.2(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2))
+      postcss-load-config: 4.0.2(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2))
       typescript: 5.4.5
 
   svelte2tsx@0.7.1(svelte@5.0.0-next.55)(typescript@5.2.2):
@@ -21647,7 +21676,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2)):
+  tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -21666,7 +21695,7 @@ snapshots:
       postcss: 8.4.32
       postcss-import: 15.1.0(postcss@8.4.32)
       postcss-js: 4.0.1(postcss@8.4.32)
-      postcss-load-config: 4.0.1(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2))
+      postcss-load-config: 4.0.1(postcss@8.4.32)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2))
       postcss-nested: 6.0.1(postcss@8.4.32)
       postcss-selector-parser: 6.0.15
       resolve: 1.22.8
@@ -21716,14 +21745,14 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.3.107)(webpack@5.92.1(@swc/core@1.3.107)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.3.107(@swc/helpers@0.5.5))(webpack@5.92.1(@swc/core@1.3.107(@swc/helpers@0.5.5))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.31.1
-      webpack: 5.92.1(@swc/core@1.3.107)
+      webpack: 5.92.1(@swc/core@1.3.107(@swc/helpers@0.5.5))
     optionalDependencies:
       '@swc/core': 1.3.107(@swc/helpers@0.5.5)
 
@@ -21835,7 +21864,28 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.14.11)(typescript@5.2.2):
+  ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.0.4):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.14.11
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.0.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.3.107(@swc/helpers@0.5.5)
+    optional: true
+
+  ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.2.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -21856,7 +21906,28 @@ snapshots:
       '@swc/core': 1.3.107(@swc/helpers@0.5.5)
     optional: true
 
-  ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.0.4):
+  ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.4.5):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.14.11
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.4.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.3.107(@swc/helpers@0.5.5)
+    optional: true
+
+  ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.5.1)(typescript@5.0.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -21875,27 +21946,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.3.107(@swc/helpers@0.5.5)
-
-  ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.4.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.5.1
-      acorn: 8.11.3
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.4.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.3.107(@swc/helpers@0.5.5)
-    optional: true
 
   ts-node@9.1.1(typescript@5.0.4):
     dependencies:
@@ -21920,16 +21970,16 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsup-preset-solid@2.2.0(esbuild@0.21.5)(solid-js@1.8.17)(tsup@8.1.0(@swc/core@1.3.107)(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5)):
+  tsup-preset-solid@2.2.0(esbuild@0.21.5)(solid-js@1.8.17)(tsup@8.1.0(@swc/core@1.3.107(@swc/helpers@0.5.5))(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)):
     dependencies:
       esbuild-plugin-solid: 0.5.0(esbuild@0.21.5)(solid-js@1.8.17)
-      tsup: 8.1.0(@swc/core@1.3.107)(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5)
+      tsup: 8.1.0(@swc/core@1.3.107(@swc/helpers@0.5.5))(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)
     transitivePeerDependencies:
       - esbuild
       - solid-js
       - supports-color
 
-  tsup@8.0.1(@swc/core@1.3.107)(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.0.4))(typescript@5.0.4):
+  tsup@8.0.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.0.4))(typescript@5.0.4):
     dependencies:
       bundle-require: 4.0.2(esbuild@0.19.12)
       cac: 6.7.14
@@ -21939,7 +21989,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.1(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.0.4))
+      postcss-load-config: 4.0.1(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.0.4))
       resolve-from: 5.0.0
       rollup: 4.6.1
       source-map: 0.8.0-beta.0
@@ -21953,7 +22003,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  tsup@8.1.0(@swc/core@1.3.107)(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.4.5))(typescript@5.4.5):
+  tsup@8.1.0(@swc/core@1.3.107(@swc/helpers@0.5.5))(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.21.5)
       cac: 6.7.14
@@ -21963,7 +22013,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@20.5.1)(typescript@5.4.5))
+      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.4.5))
       resolve-from: 5.0.0
       rollup: 4.18.1
       source-map: 0.8.0-beta.0
@@ -21977,7 +22027,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  tsup@8.2.0(@swc/core@1.3.107)(jiti@1.21.0)(postcss@8.4.39)(typescript@5.0.4)(yaml@2.4.5):
+  tsup@8.2.0(@swc/core@1.3.107(@swc/helpers@0.5.5))(jiti@1.21.0)(postcss@8.4.39)(typescript@5.0.4)(yaml@2.4.5):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.0)
       cac: 6.7.14
@@ -22679,7 +22729,7 @@ snapshots:
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.14.11
-      '@vitest/browser': 1.6.0(vitest@1.2.2)
+      '@vitest/browser': 1.6.0(playwright@1.45.2)(vitest@1.2.2)(webdriverio@8.39.1(encoding@0.1.13)(typescript@5.2.2))
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -22860,13 +22910,48 @@ snapshots:
       - utf-8-validate
     optional: true
 
+  webdriverio@8.39.1(encoding@0.1.13)(typescript@5.2.2):
+    dependencies:
+      '@types/node': 20.14.11
+      '@wdio/config': 8.39.0
+      '@wdio/logger': 8.38.0
+      '@wdio/protocols': 8.38.0
+      '@wdio/repl': 8.24.12
+      '@wdio/types': 8.39.0
+      '@wdio/utils': 8.39.0
+      archiver: 7.0.1
+      aria-query: 5.3.0
+      css-shorthand-properties: 1.1.1
+      css-value: 0.0.1
+      devtools-protocol: 0.0.1302984
+      grapheme-splitter: 1.0.4
+      import-meta-resolve: 4.1.0
+      is-plain-obj: 4.1.0
+      jszip: 3.10.1
+      lodash.clonedeep: 4.5.0
+      lodash.zip: 4.2.0
+      minimatch: 9.0.5
+      puppeteer-core: 20.9.0(encoding@0.1.13)(typescript@5.2.2)
+      query-selector-shadow-dom: 1.0.1
+      resq: 1.11.0
+      rgb2hex: 0.2.5
+      serialize-error: 11.0.3
+      webdriver: 8.39.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - typescript
+      - utf-8-validate
+    optional: true
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@4.0.2: {}
 
   webpack-sources@3.2.3: {}
 
-  webpack@5.92.1(@swc/core@1.3.107):
+  webpack@5.92.1(@swc/core@1.3.107(@swc/helpers@0.5.5)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -22889,7 +22974,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.3.107)(webpack@5.92.1(@swc/core@1.3.107))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.107(@swc/helpers@0.5.5))(webpack@5.92.1(@swc/core@1.3.107(@swc/helpers@0.5.5)))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Description

Changes:
- Updated JSX transform configuration from "jsx": "react" to "jsx": "react-jsx".
- Dropped support for React 16 as the new JSX runtime requires React 17 or higher.

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
