### PR TITLE
Fix wrong description of autoResizeCanvas in README

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -83,7 +83,6 @@ The `DotLottieReactProps` extends the `HTMLCanvasElement` Props and accepts all 
 | `playOnHover`           | boolean                                |          | false                 | Determines if the animation should play on mouse hover and pause on mouse out.                                                                                                                                                                     |   |
 | `dotLottieRefCallback`  | React.RefCallback\<DotLottie \|  null> |          | undefined             | Callback function that receives a reference to the [`dotLottie`](../web/README.md) web player instance.                                                                                                                                            |   |
 | `useFrameInterpolation` | boolean                                |          | true                  | Determines if the animation should update on subframes. If set to false, the original AE frame rate will be maintained. If set to true, it will refresh at each requestAnimationFrame, including intermediate values. The default setting is true. |   |
-| `autoResizeCanvas`      | boolean                                |          | true                  | Determines if the canvas should resize automatically to its container                                                                                                                                                                              |   |
 | `marker`                | string                                 |          | undefined             | The Lottie named marker to play.                                                                                                                                                                                                                   |   |
 
 #### RenderConfig
@@ -93,6 +92,7 @@ The `renderConfig` object accepts the following properties:
 | Property name      | Type   | Required | Default                       | Description             |
 | ------------------ | ------ | :------: | ----------------------------- | ----------------------- |
 | `devicePixelRatio` | number |          | window\.devicePixelRatio \| 1 | The device pixel ratio. |
+| `renderConfig.autoResize`       | boolean|          | true                          | Determines if the canvas should resize automatically to its container |
 
 ## Custom Playback Controls
 


### PR DESCRIPTION
Fixes #435

Update the description of `autoResizeCanvas` in `packages/react/README.md` to reflect its move to `renderConfig.autoResize`.

