### PR TITLE
fix: 🐛 cancel animation frames properly in _draw method

### DIFF
--- a/.changeset/fuzzy-drinks-try.md
+++ b/.changeset/fuzzy-drinks-try.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+fix: ensure proper cancellation of animation frames in \_draw method


### PR DESCRIPTION
## Description

The main issue was that animation frames weren't being properly cancelled in certain scenarios, leading to:
- Memory leaks as animation frames continued to be requested
- Potential for multiple concurrent animation loops running simultaneously
- Lack of cleanup during error conditions

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
