### PR TITLE
fix: prevent IndexSizeError when buffer size doesn't match canvas dimensions

### DIFF
--- a/.changeset/popular-ladybugs-carry.md
+++ b/.changeset/popular-ladybugs-carry.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+fix: prevent `IndexSizeError` when buffer size doesn't match canvas dimensions

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -492,7 +492,7 @@ export class DotLottie {
       const buffer = this._dotLottieCore.buffer() as ArrayBuffer;
       const expectedLength = this._canvas.width * this._canvas.height * 4;
 
-      if (buffer.byteLength < expectedLength) {
+      if (buffer.byteLength !== expectedLength) {
         console.warn(`Buffer size mismatch: got ${buffer.byteLength}, expected ${expectedLength}`);
 
         return false;

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -490,7 +490,15 @@ export class DotLottie {
 
     if (rendered) {
       const buffer = this._dotLottieCore.buffer() as ArrayBuffer;
-      const clampedBuffer = new Uint8ClampedArray(buffer, 0, this._canvas.width * this._canvas.height * 4);
+      const expectedLength = this._canvas.width * this._canvas.height * 4;
+
+      if (buffer.byteLength < expectedLength) {
+        console.warn(`Buffer size mismatch: got ${buffer.byteLength}, expected ${expectedLength}`);
+
+        return false;
+      }
+
+      const clampedBuffer = new Uint8ClampedArray(buffer, 0, expectedLength);
 
       let imageData = null;
 


### PR DESCRIPTION
## Description

fix #465

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
