### PR TITLE
fix: destroy instance on WASM RuntimeError in animation loop

### DIFF
--- a/apps/dotlottie-react-example/src/App.tsx
+++ b/apps/dotlottie-react-example/src/App.tsx
@@ -3,6 +3,7 @@ import { DotLottieWorkerReact, DotLottieWorker, setWasmUrl } from '@lottiefiles/
 import React, { useState } from 'react';
 
 const animations = [
+  'https://lottie.host/68f06eea-5f90-4e58-b51e-3abe1fbd74b8/llUlrzgWDQ.lottie',
   'https://lottie.host/e641272e-039b-4612-96de-138acfbede6e/bc0sW78EeR.lottie',
   './markers_example.json',
   'https://lottie.host/f315768c-a29b-41fd-b5a8-a1c1dfb36cd2/CRiiNg8fqQ.lottie',

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -528,7 +528,7 @@ export class DotLottie {
   }
 
   private _draw(): void {
-    if (this._dotLottieCore === null || this._context === null || !this._dotLottieCore.isPlaying()) return;
+    if (this._dotLottieCore === null || !this._dotLottieCore.isPlaying()) return;
 
     try {
       const nextFrame = Math.round(this._dotLottieCore.requestFrame() * 1000) / 1000;
@@ -562,12 +562,11 @@ export class DotLottie {
     } catch (error) {
       console.error('Error in animation frame:', error);
 
-      // Allows users to catch rendering errors
-      this._eventManager.dispatch({ type: 'renderError', error: new Error(`Error in animation frame: ${error}`) });
+      this._eventManager.dispatch({ type: 'renderError', error: error as unknown as Error });
 
-      if (this._animationFrameId !== null) {
-        this._frameManager.cancelAnimationFrame(this._animationFrameId);
-        this._animationFrameId = null;
+      // destroy the instance if it's a runtime error
+      if (error instanceof WebAssembly.RuntimeError) {
+        this.destroy();
       }
     }
   }

--- a/packages/web/tests/dotlottie.test.ts
+++ b/packages/web/tests/dotlottie.test.ts
@@ -2272,7 +2272,7 @@ describe.each([
     const onFrame = vi.fn();
 
     // info: cast DotLottie to any to bypass the type check, since this is only for the non-worker version
-    dotLottie = new (DotLottie as unknown)({
+    dotLottie = new (DotLottie as any)({
       canvas: {
         width: 100,
         height: 100,


### PR DESCRIPTION
## Description

- To avoid memory leaks on RenderError
- To prevent the web page from hanging on RenderError

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
