### PR TITLE
fix: validate exact buffer size equality in canvas rendering

### DIFF
--- a/.changeset/loud-trains-share.md
+++ b/.changeset/loud-trains-share.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+fix: validate exact buffer size equality in canvas rendering

--- a/packages/web/src/constants.ts
+++ b/packages/web/src/constants.ts
@@ -9,3 +9,5 @@ export const PACKAGE_VERSION = '__PACKAGE_VERSION__';
 export const PACKAGE_NAME = '__PACKAGE_NAME__';
 
 export const DEFAULT_DPR_FACTOR = 0.75;
+
+export const BYTES_PER_PIXEL = 4;

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -1,5 +1,5 @@
 import { AnimationFrameManager } from './animation-frame-manager';
-import { IS_BROWSER } from './constants';
+import { IS_BROWSER, BYTES_PER_PIXEL } from './constants';
 import type { DotLottiePlayer, MainModule, Mode as CoreMode, VectorFloat, Marker, Fit as CoreFit } from './core';
 import { DotLottieWasmLoader } from './core';
 import type { EventListener, EventType } from './event-manager';
@@ -501,7 +501,7 @@ export class DotLottie {
       if (this._context) {
         const buffer = this._dotLottieCore.buffer() as ArrayBuffer;
 
-        const expectedLength = this._canvas.width * this._canvas.height * 4;
+        const expectedLength = this._canvas.width * this._canvas.height * BYTES_PER_PIXEL;
 
         if (buffer.byteLength !== expectedLength) {
           console.warn(`Buffer size mismatch: got ${buffer.byteLength}, expected ${expectedLength}`);

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -500,9 +500,18 @@ export class DotLottie {
       // Only process visual output if we have a canvas with a valid context
       if (this._context) {
         const buffer = this._dotLottieCore.buffer() as ArrayBuffer;
-        const clampedBuffer = new Uint8ClampedArray(buffer, 0, this._canvas.width * this._canvas.height * 4);
+
+        const expectedLength = this._canvas.width * this._canvas.height * 4;
+
+        if (buffer.byteLength !== expectedLength) {
+          console.warn(`Buffer size mismatch: got ${buffer.byteLength}, expected ${expectedLength}`);
+
+          return false;
+        }
 
         let imageData = null;
+
+        const clampedBuffer = new Uint8ClampedArray(buffer, 0, buffer.byteLength);
 
         /* 
           In Node.js, the ImageData constructor is not available. 


### PR DESCRIPTION
## Description

fix #465


<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
