### PR TITLE
feat(vue): add missing options

### DIFF
--- a/.changeset/common-tires-rush.md
+++ b/.changeset/common-tires-rush.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-vue': minor
+---
+
+feat: adding missing options

--- a/packages/vue/src/dotlottie.ts
+++ b/packages/vue/src/dotlottie.ts
@@ -11,6 +11,7 @@ import {
   defineComponent,
   toRefs,
   type PropType,
+  computed,
 } from 'vue';
 
 export { type DotLottie };
@@ -44,6 +45,7 @@ export const DotLottieVue = defineComponent({
     playOnHover: { type: Boolean as PropType<DotLottieVueProps['playOnHover']>, required: false },
     themeData: { type: String as PropType<DotLottieVueProps['themeData']>, required: false },
     themeId: { type: String as PropType<DotLottieVueProps['themeId']>, required: false },
+    layout: { type: Object as PropType<DotLottieVueProps['layout']>, required: false },
   },
 
   setup(props: DotLottieVueProps, { attrs, expose }: SetupContext): () => VNode {
@@ -51,16 +53,56 @@ export const DotLottieVue = defineComponent({
     const {
       animationId,
       backgroundColor,
+      data,
+      layout,
       loop,
       marker,
       mode,
       playOnHover,
+      renderConfig,
       segment,
       speed,
+      src,
       themeId,
       useFrameInterpolation,
     } = toRefs(props);
     let dotLottie: DotLottie | null = null;
+    const shouldAutoplay = computed(() => {
+      let _shouldAutoplay = props.autoplay;
+
+      if (typeof playOnHover?.value !== 'undefined' && playOnHover.value) {
+        _shouldAutoplay = false;
+      }
+
+      return _shouldAutoplay;
+    });
+
+    /**
+     * Wrap dotLottie-web's load function
+     */
+    const load: DotLottie['load'] = (config = {}) => {
+      if (dotLottie === null) {
+        return;
+      }
+
+      dotLottie.load({
+        animationId: animationId?.value,
+        backgroundColor: backgroundColor?.value,
+        data: data?.value,
+        layout: layout?.value,
+        loop: loop?.value,
+        marker: marker?.value,
+        mode: mode?.value,
+        autoplay: shouldAutoplay.value,
+        renderConfig: renderConfig?.value,
+        segment: segment?.value,
+        speed: speed?.value,
+        src: src?.value,
+        themeId: themeId?.value,
+        useFrameInterpolation: useFrameInterpolation?.value,
+        ...config,
+      });
+    };
 
     // Prop change
     watch(
@@ -174,20 +216,57 @@ export const DotLottieVue = defineComponent({
         }
       },
     );
+    watch(
+      () => layout?.value,
+      (newVal) => {
+        if (dotLottie && typeof newVal !== 'undefined') {
+          dotLottie.setLayout(newVal);
+        }
+      },
+      { deep: true },
+    );
+
+    watch(
+      () => renderConfig?.value,
+      (newVal) => {
+        if (dotLottie && typeof newVal !== 'undefined') {
+          dotLottie.setRenderConfig(newVal);
+        }
+      },
+      { deep: true },
+    );
+
+    watch(
+      () => data?.value,
+      (newVal) => {
+        if (dotLottie && typeof newVal !== 'object' && typeof newVal !== 'string') {
+          return;
+        }
+        load({
+          data: newVal,
+        });
+      },
+      { deep: true },
+    );
+
+    watch(
+      () => src?.value,
+      (newVal) => {
+        if (dotLottie && typeof newVal !== 'undefined') {
+          load({
+            src: newVal,
+          });
+        }
+      },
+    );
 
     onMounted(() => {
       if (!canvas.value) return;
 
-      let shouldAutoplay = props.autoplay;
-
-      if (typeof playOnHover?.value !== 'undefined' && playOnHover.value) {
-        shouldAutoplay = false;
-      }
-
       dotLottie = new DotLottie({
         canvas: canvas.value,
         ...props,
-        autoplay: shouldAutoplay,
+        autoplay: shouldAutoplay.value,
       });
 
       if (playOnHover?.value) {

--- a/packages/vue/src/dotlottie.ts
+++ b/packages/vue/src/dotlottie.ts
@@ -239,12 +239,13 @@ export const DotLottieVue = defineComponent({
     watch(
       () => data?.value,
       (newVal) => {
-        if (dotLottie && typeof newVal !== 'object' && typeof newVal !== 'string') {
-          return;
+        const isStrOrObject = typeof newVal === 'object' || typeof newVal === 'string';
+
+        if (dotLottie && isStrOrObject) {
+          load({
+            data: newVal,
+          });
         }
-        load({
-          data: newVal,
-        });
       },
       { deep: true },
     );


### PR DESCRIPTION
## Description

Adding missing options and watcher for vue package, slightly refactored code.

while i was using react code as reference of how to handle these options I found this: https://github.com/LottieFiles/dotlottie-web/blob/main/packages/react/src/base-dotlottie-react.tsx#L185-L189 and github.com/LottieFiles/dotlottie-web/blob/main/packages/react/src/base-dotlottie-react.tsx#L176-L180

wondering if this is correct as i think `src` and `data` should place after `...configRef.current`.

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
