### PR TITLE
fix: backgroundColor prop not applied on initial render in dotlottie-wc

### DIFF
--- a/.changeset/sour-hairs-drop.md
+++ b/.changeset/sour-hairs-drop.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-wc': patch
+---
+
+fix: backgroundColor prop not applied on initial render in dotlottie-wc

--- a/packages/wc/src/base-dotlottie-wc.ts
+++ b/packages/wc/src/base-dotlottie-wc.ts
@@ -93,7 +93,7 @@ export abstract class BaseDotLottieWC<T extends DotLottie | DotLottieWorker> ext
       animationId: this.animationId,
       stateMachineConfig: this.stateMachineConfig,
       stateMachineId: this.stateMachineId,
-
+      backgroundColor: this.backgroundColor,
       workerId: this.workerId,
     });
   }
@@ -192,6 +192,7 @@ export abstract class BaseDotLottieWC<T extends DotLottie | DotLottieWorker> ext
         themeId: this.themeId,
         stateMachineConfig: this.stateMachineConfig,
         stateMachineId: this.stateMachineId,
+        backgroundColor: this.backgroundColor,
       });
     }
 
@@ -211,6 +212,7 @@ export abstract class BaseDotLottieWC<T extends DotLottie | DotLottieWorker> ext
         animationId: this.animationId,
         stateMachineConfig: this.stateMachineConfig,
         stateMachineId: this.stateMachineId,
+        backgroundColor: this.backgroundColor,
       });
     }
 


### PR DESCRIPTION
the backgroundColor attribute was not working because `attributeChangedCallback` fires before `connectedCallback`, when `this.dotLottie` is still null. the callback would return early, and `_init()` never passed `backgroundColor` in the config.

Added `backgroundColor` to:
- _init() config for initial render
- load() config when src changes
- load() config when data changes

## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
