### PR TITLE
fix: buffer size mismatch warnings

### DIFF
--- a/.changeset/real-pears-push.md
+++ b/.changeset/real-pears-push.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+fix: buffer size mismatch warnings

--- a/apps/dotlottie-react-example/src/App.tsx
+++ b/apps/dotlottie-react-example/src/App.tsx
@@ -25,7 +25,12 @@ function App() {
   const [marker, setMarker] = useState('');
   const [allMarkers, setAllMarkers] = useState<string[]>([]);
   const [animationsIds, setAnimationsIds] = useState<string[]>([]);
-  const [currentAnimationId, setCurrentAnimationId] = useState<string>('crying');
+  const [currentAnimationId, setCurrentAnimationId] = useState<string>('');
+  const [isMounted, setIsMounted] = useState(false);
+
+  React.useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   React.useEffect(() => {
     function updateCurrentFrame(event: { currentFrame: number }) {
@@ -69,28 +74,31 @@ function App() {
           marginBottom: '2000px',
         }}
       ></div>
-      <DotLottieWorkerReact
-        dotLottieRefCallback={setDotLottie}
-        useFrameInterpolation={useFrameInterpolation}
-        src={animations[srcIdx]}
-        autoplay
-        loop={loop}
-        speed={speed}
-        playOnHover={playOnHover}
-        renderConfig={{
-          autoResize: autoResizeCanvas,
-        }}
-        marker={marker}
-        style={{
-          margin: '2px',
-          border: '1px solid white',
-        }}
-        animationId={currentAnimationId}
-      />
+      {isMounted && (
+        <DotLottieWorkerReact
+          dotLottieRefCallback={setDotLottie}
+          useFrameInterpolation={useFrameInterpolation}
+          src={animations[srcIdx]}
+          autoplay
+          loop={loop}
+          speed={speed}
+          playOnHover={playOnHover}
+          renderConfig={{
+            autoResize: autoResizeCanvas,
+          }}
+          marker={marker}
+          style={{
+            margin: '2px',
+            border: '1px solid white',
+          }}
+          animationId={currentAnimationId}
+        />
+      )}
       <input type="range" min="0" max="100" defaultValue="0" value={progress} />
       <label>
         Marker:
         <select
+          value={marker}
           onChange={(event) => {
             setMarker(event.target.value);
           }}
@@ -181,7 +189,8 @@ function App() {
       <div>
         <label>
           Animation ID:
-          <select value={currentAnimationId} onChange={(event) => setCurrentAnimationId(event.target.value)}>
+          <select value={currentAnimationId || ''} onChange={(event) => setCurrentAnimationId(event.target.value)}>
+            <option value="">Select an animation</option>
             {animationsIds.map((animationId) => (
               <option key={animationId} value={animationId}>
                 {animationId}

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -139,6 +139,10 @@ export class DotLottie {
 
   private _boundOnPointerLeave: ((event: PointerEvent) => void) | null = null;
 
+  private _bufferMismatchCount = 0;
+
+  private _lastExpectedBufferSize = 0;
+
   public constructor(
     config: Omit<Config, 'canvas'> & {
       canvas: HTMLCanvasElement | OffscreenCanvas | RenderSurface;
@@ -625,11 +629,31 @@ export class DotLottie {
 
       const expectedLength = this._canvas.width * this._canvas.height * BYTES_PER_PIXEL;
 
+      /* 
+        frame buffer size mismatch can occur temporarily during resize operations when the WASM buffer allocation hasn't completed yet
+      */
       if (buffer.byteLength !== expectedLength) {
-        console.warn(`Buffer size mismatch: got ${buffer.byteLength}, expected ${expectedLength}`);
+        if (this._lastExpectedBufferSize === expectedLength) {
+          this._bufferMismatchCount += 1;
+        } else {
+          this._bufferMismatchCount = 1;
+          this._lastExpectedBufferSize = expectedLength;
+        }
+
+        if (this._bufferMismatchCount === 10) {
+          console.warn(
+            `[dotlottie-web] Persistent buffer size mismatch detected. ` +
+              `Expected ${expectedLength} bytes for canvas ${this._canvas.width}x${this._canvas.height}, ` +
+              `but got ${buffer.byteLength} bytes. ` +
+              `This may indicate a WASM memory allocation issue or invalid canvas dimensions.`,
+          );
+        }
 
         return;
       }
+
+      this._bufferMismatchCount = 0;
+      this._lastExpectedBufferSize = expectedLength;
 
       let imageData = null;
 
@@ -908,6 +932,7 @@ export class DotLottie {
     const resized = this._dotLottieCore.resize(this._canvas.width, this._canvas.height);
 
     if (resized) {
+      this._dotLottieCore.render();
       this._draw();
     }
   }

--- a/packages/web/tests/dotlottie.test.ts
+++ b/packages/web/tests/dotlottie.test.ts
@@ -616,9 +616,7 @@ describe.each([
     expect(onDestroy).toHaveBeenCalledTimes(1);
   });
 
-  (isWorker ? test.skip : test)('logs warning and exits early on buffer size mismatch', async () => {
-    const consoleWarnSpy = vi.spyOn(console, 'warn');
-
+  (isWorker ? test.skip : test)('exits early on buffer size mismatch without rendering', async () => {
     const onReady = vi.fn();
     const onRender = vi.fn();
 
@@ -641,19 +639,11 @@ describe.each([
 
     vi.spyOn(dotLottieCore, 'buffer').mockReturnValue(wrongSizeBuffer);
 
-    const expectedLength = canvas.width * canvas.height * BYTES_PER_PIXEL;
-
     onRender.mockClear();
 
     await dotLottie.setFrame(1);
 
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      `Buffer size mismatch: got ${wrongSizeBuffer.byteLength}, expected ${expectedLength}`,
-    );
-
     expect(onRender).not.toHaveBeenCalled();
-
-    consoleWarnSpy.mockRestore();
   });
 
   test('animationSize() returns the animation dimensions', async () => {
@@ -707,6 +697,65 @@ describe.each([
         expect(canvas.width).toBe(2 * originalCanvasWidth);
         expect(canvas.height).toBe(2 * originalCanvasHeight);
       });
+    });
+
+    (isWorker ? test.skip : test)('should not warn for transient buffer mismatches during resize', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn');
+      const onReady = vi.fn();
+
+      dotLottie = new DotLottie({
+        canvas,
+        src,
+        autoplay: true,
+      });
+
+      dotLottie.addEventListener('ready', onReady);
+
+      await vi.waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+
+      const dotLottieCore = (dotLottie as DotLottieClass)['_dotLottieCore'] as DotLottiePlayer;
+
+      const originalBuffer = dotLottieCore.buffer.bind(dotLottieCore);
+
+      const initialWidth = canvas.width;
+      const initialHeight = canvas.height;
+      const initialBufferSize = initialWidth * initialHeight * BYTES_PER_PIXEL;
+
+      const oldBuffer = new ArrayBuffer(initialBufferSize);
+
+      let resizeCallCount = 0;
+
+      vi.spyOn(dotLottieCore, 'resize').mockImplementation(() => {
+        resizeCallCount += 1;
+
+        return true;
+      });
+
+      let drawCallCount = 0;
+
+      vi.spyOn(dotLottieCore, 'buffer').mockImplementation(() => {
+        drawCallCount += 1;
+        if (resizeCallCount > 0 && drawCallCount < 10) {
+          return oldBuffer;
+        }
+
+        return originalBuffer();
+      });
+
+      canvas.style.width = '400px';
+      canvas.style.height = '400px';
+
+      dotLottie.resize();
+
+      await sleep(200);
+
+      const bufferWarnings = consoleWarnSpy.mock.calls.filter((call) =>
+        String(call[0]).includes('buffer size mismatch'),
+      );
+
+      expect(bufferWarnings.length).toBeLessThanOrEqual(1);
+
+      consoleWarnSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Description

Problem:
The resize() method was calling _draw() immediately after _dotLottieCore.resize() without calling render() first. In the dotLottie architecture, resize() updates internal WASM dimensions, but the actual buffer reallocation happens during render(). This caused _draw() to see a mismatched buffer size.

> Note: added a simple tracker to detect buffer-size mismatches in case the WASM allocation fails or the canvas size is incorrect.

fixes #587 


<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
