### PR TITLE
feat: add AI coding tool guidelines (installable skill)

### DIFF
--- a/guidelines/README.md
+++ b/guidelines/README.md
@@ -1,0 +1,55 @@
+# dotLottie Guidelines for AI Coding Tools
+
+Install dotLottie implementation guidelines as a skill/command for your AI coding assistant.
+
+## Quick Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/LottieFiles/dotlottie-web/main/guidelines/install.sh | bash
+```
+
+## Supported Tools
+
+| Tool | Location | Usage |
+|------|----------|-------|
+| Claude Code | `~/.claude/commands/` | `/dotlottie` or ask naturally |
+| Cursor | `~/.cursor/commands/` | `@dotlottie-guidelines` |
+| OpenCode | `~/.config/opencode/command/` | Reference in prompts |
+| Windsurf | `~/.codeium/windsurf/memories/` | Automatic context |
+| Gemini CLI | `~/.gemini/commands/` | `/dotlottie-guidelines` |
+| Codex CLI | `~/.codex/commands/` | Reference in prompts |
+
+## Manual Installation
+
+If you prefer manual installation or want to add to a project:
+
+```bash
+# Download to current directory
+curl -sL https://raw.githubusercontent.com/LottieFiles/dotlottie-web/main/guidelines/command.md > DOTLOTTIE.md
+
+# Or add to your project's AGENTS.md / CLAUDE.md
+```
+
+## What's Included
+
+The guidelines cover:
+
+- **Package Selection** - When to use `dotlottie-web` vs `dotlottie-react`
+- **Basic Implementation** - Setup for vanilla JS and React
+- **State Machines** - Interactive animations without code
+- **Theming** - Runtime customization with slots
+- **Markers & Segments** - Playing specific parts of animations
+- **Performance** - Lazy loading, freezing, cleanup
+- **Common Patterns** - Hover, click, scroll interactions
+- **Debugging** - Inspecting animation state
+
+## Contributing
+
+Found an issue or want to improve the guidelines? PRs welcome!
+
+## Resources
+
+- [dotLottie Documentation](https://developers.lottiefiles.com/docs/dotlottie-player)
+- [dotlottie-web GitHub](https://github.com/LottieFiles/dotlottie-web)
+- [dotLottie Format](https://dotlottie.io)
+- [LottieFiles Creator](https://creators.lottiefiles.com)

--- a/guidelines/command.md
+++ b/guidelines/command.md
@@ -1,0 +1,460 @@
+---
+name: dotlottie
+description: Guidelines for implementing dotLottie animations in web applications
+---
+
+# dotLottie Implementation Guidelines
+
+You are an expert at implementing Lottie animations using dotLottie runtimes. Follow these guidelines when working with dotLottie in web projects.
+
+## Package Selection
+
+### Use `@lottiefiles/dotlottie-web` when:
+- You need direct canvas control
+- Building framework-agnostic code
+- Maximum performance is critical
+- You want the smallest bundle
+
+### Use `@lottiefiles/dotlottie-react` when:
+- Building React applications
+- You want declarative component API
+- You need React lifecycle integration
+
+## Installation
+
+```bash
+# Web (vanilla JS, Vue, Svelte, etc.)
+npm install @lottiefiles/dotlottie-web
+
+# React
+npm install @lottiefiles/dotlottie-react
+```
+
+## Basic Implementation
+
+### Vanilla JavaScript
+```typescript
+import { DotLottie } from '@lottiefiles/dotlottie-web';
+
+const dotLottie = new DotLottie({
+  canvas: document.getElementById('canvas') as HTMLCanvasElement,
+  src: 'https://example.com/animation.lottie',
+  autoplay: true,
+  loop: true,
+});
+```
+
+### React
+```tsx
+import { DotLottieReact } from '@lottiefiles/dotlottie-react';
+
+function Animation() {
+  return (
+    <DotLottieReact
+      src="https://example.com/animation.lottie"
+      autoplay
+      loop
+    />
+  );
+}
+```
+
+### React with Instance Control
+```tsx
+import { useRef } from 'react';
+import { DotLottieReact } from '@lottiefiles/dotlottie-react';
+import type { DotLottie } from '@lottiefiles/dotlottie-web';
+
+function Animation() {
+  const dotLottieRef = useRef<DotLottie | null>(null);
+
+  return (
+    <DotLottieReact
+      src="https://example.com/animation.lottie"
+      dotLottieRefCallback={(dotLottie) => (dotLottieRef.current = dotLottie)}
+    />
+  );
+}
+```
+
+## .lottie vs .json
+
+**Always prefer `.lottie` format over `.json`:**
+- Smaller file size (compressed)
+- Supports multiple animations in one file
+- Embedded assets (images, fonts)
+- State machines for interactivity
+- Theming with slots
+
+## Web Workers (Recommended for Performance)
+
+Use `DotLottieWorker` to offload animation rendering to a Web Worker, keeping the main thread free for UI interactions:
+
+### Basic Worker Usage
+```typescript
+import { DotLottieWorker } from '@lottiefiles/dotlottie-web';
+
+const dotLottie = new DotLottieWorker({
+  canvas: document.getElementById('canvas') as HTMLCanvasElement,
+  src: 'https://example.com/animation.lottie',
+  autoplay: true,
+  loop: true,
+});
+```
+
+### Worker Grouping (Multiple Animations)
+By default, all `DotLottieWorker` instances share the same worker. Group animations into separate workers using `workerId`:
+
+```typescript
+// Hero animation in its own worker
+const heroAnimation = new DotLottieWorker({
+  canvas: heroCanvas,
+  src: 'hero.lottie',
+  workerId: 'hero-worker',
+});
+
+// UI animations share a different worker
+const buttonAnimation = new DotLottieWorker({
+  canvas: buttonCanvas,
+  src: 'button.lottie',
+  workerId: 'ui-worker',
+});
+```
+
+### When to Use Workers
+- **Use `DotLottieWorker`** for:
+  - Multiple simultaneous animations
+  - Complex animations with many layers
+  - Animations running alongside heavy JS operations
+  - Mobile devices where main thread performance is critical
+
+- **Use regular `DotLottie`** for:
+  - Single simple animations
+  - When you need synchronous frame access
+  - SSR environments (workers not available)
+
+### React with Workers
+```tsx
+import { DotLottieWorkerReact } from '@lottiefiles/dotlottie-react';
+
+function Animation() {
+  return (
+    <DotLottieWorkerReact
+      src="animation.lottie"
+      autoplay
+      loop
+      workerId="my-worker" // Optional: dedicate to specific worker
+    />
+  );
+}
+```
+
+## State Machines (Interactivity)
+
+State machines enable interactive animations without code. See the [State Machine Guide](https://github.com/LottieFiles/dotlottie-web/wiki/dotLottie-State-Machine-Guide) for details.
+
+```typescript
+const dotLottie = new DotLottie({
+  canvas,
+  src: 'interactive.lottie', // Contains state machine
+  autoplay: true,
+});
+
+// Fire events to trigger state transitions
+dotLottie.stateMachineFireEvent('click');
+dotLottie.stateMachineFireEvent('hover');
+dotLottie.stateMachineFireEvent('custom-event');
+
+// Set numeric/boolean/string inputs for state conditions
+// See: https://github.com/LottieFiles/dotlottie-web/wiki/dotLottie-State-Machine-Guide#working-with-inputs
+dotLottie.stateMachineSetNumericInput('progress', 0.5);
+dotLottie.stateMachineSetBooleanInput('isActive', true);
+dotLottie.stateMachineSetStringInput('mode', 'dark');
+```
+
+### State Machine Events
+- `click` - User click/tap
+- `hover` - Mouse enter
+- `unhover` - Mouse leave  
+- `complete` - Animation finished
+- Custom events defined in the state machine
+
+## Theming with Slots
+
+Slots allow runtime color/value customization. Themes follow the [dotLottie 2.0 spec](https://dotlottie.io/spec/2.0/#themes).
+
+```typescript
+const dotLottie = new DotLottie({
+  canvas,
+  src: 'themed.lottie',
+  themeId: 'dark-mode', // Use embedded theme by ID
+});
+
+// Or apply theme data directly (JSON string per dotLottie 2.0 spec)
+// See: https://dotlottie.io/spec/2.0/#themes
+dotLottie.setThemeData(JSON.stringify({
+  rules: [
+    { id: 'primary-color', value: [1, 0.34, 0.13] }, // RGB values 0-1
+  ]
+}));
+```
+
+## Markers & Segments
+
+### Playing Specific Segments
+```typescript
+// Play frames 0-60
+dotLottie.setSegment(0, 60);
+dotLottie.play();
+
+// Play by marker name (defined in animation)
+dotLottie.setMarker('intro');
+dotLottie.play();
+```
+
+### Getting Markers
+```typescript
+const markers = dotLottie.markers();
+// Returns: [{ name: 'intro', time: 0, duration: 60 }, ...]
+```
+
+## Event Handling
+
+```typescript
+dotLottie.addEventListener('load', () => {
+  console.log('Animation loaded');
+});
+
+dotLottie.addEventListener('play', () => {
+  console.log('Playing');
+});
+
+dotLottie.addEventListener('complete', () => {
+  console.log('Animation completed');
+});
+
+dotLottie.addEventListener('frame', ({ currentFrame }) => {
+  console.log('Frame:', currentFrame);
+});
+
+// Clean up
+dotLottie.removeEventListener('load', handler);
+```
+
+## Performance Best Practices
+
+### 1. Use Web Workers for Complex Animations
+```typescript
+import { DotLottieWorker } from '@lottiefiles/dotlottie-web';
+
+// Offload rendering to worker thread
+const dotLottie = new DotLottieWorker({
+  canvas,
+  src: 'complex-animation.lottie',
+});
+```
+
+### 2. Lazy Load Animations
+```typescript
+// Only load when visible
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      loadAnimation();
+      observer.disconnect();
+    }
+  });
+});
+observer.observe(container);
+```
+
+### 3. Auto-Freeze is Enabled by Default
+DotLottie automatically freezes animations when they're not visible (offscreen). To disable this behavior:
+
+```typescript
+const dotLottie = new DotLottie({
+  canvas,
+  src: 'animation.lottie',
+  renderConfig: {
+    freezeOnOffscreen: false, // Disable auto-freeze (not recommended)
+  },
+});
+```
+
+### 4. Device Pixel Ratio
+By default, devicePixelRatio is set to 75% of the actual value for better performance. For full retina quality (with higher performance cost):
+
+```typescript
+const dotLottie = new DotLottie({
+  canvas,
+  src: 'animation.lottie',
+  renderConfig: {
+    devicePixelRatio: window.devicePixelRatio, // Full retina (higher CPU/GPU)
+  },
+});
+```
+
+### 5. Clean Up (Vanilla JS only)
+```typescript
+// Always destroy when done (vanilla JS)
+dotLottie.destroy();
+```
+
+**Note:** `DotLottieReact` handles cleanup automatically on unmount - no manual cleanup needed.
+
+### 6. Frame Interpolation Control
+```typescript
+const dotLottie = new DotLottie({
+  canvas,
+  src: 'animation.lottie',
+  useFrameInterpolation: true,  // Smooth playback (default)
+  // useFrameInterpolation: false, // Match original AE frame rate
+});
+```
+
+## Multi-Animation Files
+
+A single `.lottie` file can contain multiple animations:
+
+```typescript
+// Load specific animation by ID
+dotLottie.loadAnimation('animation-2');
+
+// Get all animation IDs
+const animations = dotLottie.manifest?.animations;
+// Returns: [{ id: 'animation-1' }, { id: 'animation-2' }]
+```
+
+## Canvas Sizing
+
+**Set canvas size via CSS styles** (recommended). DotLottie will automatically determine the optimal drawing area:
+
+```html
+<canvas id="canvas" style="width: 400px; height: 400px;"></canvas>
+```
+
+### Auto-Resize to Container
+Use the `autoResize` render config to automatically resize when the container changes:
+
+```typescript
+const dotLottie = new DotLottie({
+  canvas,
+  src: 'animation.lottie',
+  renderConfig: {
+    autoResize: true, // Canvas resizes to fit container
+  },
+});
+```
+
+## Common Patterns
+
+### Play on Hover
+```typescript
+canvas.addEventListener('mouseenter', () => dotLottie.play());
+canvas.addEventListener('mouseleave', () => dotLottie.pause());
+```
+
+### Play on Click (Once)
+```typescript
+canvas.addEventListener('click', () => {
+  dotLottie.setFrame(0);
+  dotLottie.setLoop(false);
+  dotLottie.play();
+});
+```
+
+### Scrub with Scroll
+```typescript
+window.addEventListener('scroll', () => {
+  const progress = window.scrollY / (document.body.scrollHeight - window.innerHeight);
+  const frame = progress * dotLottie.totalFrames;
+  dotLottie.setFrame(frame);
+});
+```
+
+### Loading States (React)
+```tsx
+function Animation() {
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  return (
+    <>
+      {!isLoaded && <Skeleton />}
+      <DotLottieReact
+        src="animation.lottie"
+        style={{ opacity: isLoaded ? 1 : 0 }}
+        dotLottieRefCallback={(dotLottie) => {
+          dotLottie.addEventListener('load', () => setIsLoaded(true));
+        }}
+      />
+    </>
+  );
+}
+```
+
+### Responsive Animation
+```tsx
+function ResponsiveAnimation() {
+  return (
+    <DotLottieReact
+      src="animation.lottie"
+      autoplay
+      loop
+      style={{ width: '100%', maxWidth: '400px' }}
+      renderConfig={{ autoResize: true }}
+    />
+  );
+}
+```
+
+## Debugging
+
+```typescript
+// Check if loaded
+console.log('Loaded:', dotLottie.isLoaded);
+
+// Get animation info
+console.log('Duration:', dotLottie.duration);
+console.log('Total Frames:', dotLottie.totalFrames);
+console.log('Current Frame:', dotLottie.currentFrame);
+console.log('Is Playing:', dotLottie.isPlaying);
+console.log('Loop:', dotLottie.loop);
+console.log('Speed:', dotLottie.speed);
+
+// Get manifest (for .lottie files)
+console.log('Manifest:', dotLottie.manifest);
+```
+
+## Error Handling
+
+```typescript
+dotLottie.addEventListener('loadError', (error) => {
+  console.error('Failed to load animation:', error);
+  // Show fallback UI
+});
+```
+
+## SSR / Next.js Considerations
+
+dotLottie requires browser APIs. For SSR frameworks:
+
+```tsx
+import dynamic from 'next/dynamic';
+
+const DotLottieReact = dynamic(
+  () => import('@lottiefiles/dotlottie-react').then(mod => mod.DotLottieReact),
+  { ssr: false }
+);
+
+function Animation() {
+  return <DotLottieReact src="animation.lottie" autoplay loop />;
+}
+```
+
+## Resources
+
+- Documentation: https://developers.lottiefiles.com/docs/dotlottie-player
+- State Machine Guide: https://github.com/LottieFiles/dotlottie-web/wiki/dotLottie-State-Machine-Guide
+- GitHub: https://github.com/LottieFiles/dotlottie-web
+- dotLottie 2.0 Spec: https://dotlottie.io/spec/2.0/
+- Create .lottie files: https://lottiefiles.com or https://creators.lottiefiles.com

--- a/guidelines/install.sh
+++ b/guidelines/install.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# dotLottie Guidelines Installer
+# https://github.com/LottieFiles/dotlottie-web
+
+set -e
+
+# Colors (only if stdout is a TTY)
+if [ -t 1 ]; then
+  GREEN='\033[32m'
+  CYAN='\033[36m'
+  DIM='\033[2m'
+  RESET='\033[0m'
+else
+  GREEN=''
+  CYAN=''
+  DIM=''
+  RESET=''
+fi
+
+REPO_URL="https://raw.githubusercontent.com/LottieFiles/dotlottie-web/main/guidelines"
+COMMAND_FILE="command.md"
+INSTALL_NAME="dotlottie-guidelines.md"
+INSTALLED=0
+
+echo ""
+printf "${CYAN}●${RESET} Installing dotLottie Guidelines…\n"
+echo ""
+
+# Claude Code
+if [ -d "$HOME/.claude" ]; then
+  mkdir -p "$HOME/.claude/commands"
+  curl -sL -o "$HOME/.claude/commands/$INSTALL_NAME" "$REPO_URL/$COMMAND_FILE"
+  printf "  ${GREEN}✓${RESET} Claude Code\n"
+  INSTALLED=$((INSTALLED + 1))
+fi
+
+# Cursor (1.6+)
+if [ -d "$HOME/.cursor" ]; then
+  mkdir -p "$HOME/.cursor/commands"
+  curl -sL -o "$HOME/.cursor/commands/$INSTALL_NAME" "$REPO_URL/$COMMAND_FILE"
+  printf "  ${GREEN}✓${RESET} Cursor\n"
+  INSTALLED=$((INSTALLED + 1))
+fi
+
+# OpenCode
+if command -v opencode &> /dev/null || [ -d "$HOME/.config/opencode" ]; then
+  mkdir -p "$HOME/.config/opencode/command"
+  curl -sL -o "$HOME/.config/opencode/command/$INSTALL_NAME" "$REPO_URL/$COMMAND_FILE"
+  printf "  ${GREEN}✓${RESET} OpenCode\n"
+  INSTALLED=$((INSTALLED + 1))
+fi
+
+# Windsurf - appends to global_rules.md
+MARKER="# dotLottie Implementation Guidelines"
+if [ -d "$HOME/.codeium" ] || [ -d "$HOME/Library/Application Support/Windsurf" ]; then
+  mkdir -p "$HOME/.codeium/windsurf/memories"
+  RULES_FILE="$HOME/.codeium/windsurf/memories/global_rules.md"
+  if [ -f "$RULES_FILE" ] && grep -q "$MARKER" "$RULES_FILE"; then
+    printf "  ${GREEN}✓${RESET} Windsurf ${DIM}(already installed)${RESET}\n"
+  else
+    if [ -f "$RULES_FILE" ]; then
+      echo "" >> "$RULES_FILE"
+    fi
+    echo "$MARKER" >> "$RULES_FILE"
+    echo "" >> "$RULES_FILE"
+    curl -sL "$REPO_URL/$COMMAND_FILE" >> "$RULES_FILE"
+    printf "  ${GREEN}✓${RESET} Windsurf\n"
+  fi
+  INSTALLED=$((INSTALLED + 1))
+fi
+
+# Gemini CLI - uses TOML command format
+if command -v gemini &> /dev/null || [ -d "$HOME/.gemini" ]; then
+  mkdir -p "$HOME/.gemini/commands"
+  TOML_FILE="$HOME/.gemini/commands/dotlottie-guidelines.toml"
+
+  # Download markdown and convert to TOML
+  CONTENT=$(curl -sL "$REPO_URL/$COMMAND_FILE" | sed '1,/^---$/d' | sed '1,/^---$/d')
+  cat > "$TOML_FILE" << 'TOMLEOF'
+description = "Guidelines for implementing dotLottie animations in web applications"
+prompt = """
+TOMLEOF
+  echo "$CONTENT" >> "$TOML_FILE"
+  echo '"""' >> "$TOML_FILE"
+
+  printf "  ${GREEN}✓${RESET} Gemini CLI\n"
+  INSTALLED=$((INSTALLED + 1))
+fi
+
+# Codex CLI
+if command -v codex &> /dev/null || [ -d "$HOME/.codex" ]; then
+  mkdir -p "$HOME/.codex/commands"
+  curl -sL -o "$HOME/.codex/commands/$INSTALL_NAME" "$REPO_URL/$COMMAND_FILE"
+  printf "  ${GREEN}✓${RESET} Codex CLI\n"
+  INSTALLED=$((INSTALLED + 1))
+fi
+
+echo ""
+
+if [ $INSTALLED -eq 0 ]; then
+  echo "No supported AI coding tools detected."
+  echo ""
+  echo "Supported tools:"
+  echo "  • Claude Code: https://claude.ai/code"
+  echo "  • Cursor: https://cursor.com"
+  echo "  • OpenCode: https://opencode.ai"
+  echo "  • Windsurf: https://codeium.com/windsurf"
+  echo "  • Gemini CLI: https://github.com/google-gemini/gemini-cli"
+  echo "  • Codex CLI: https://github.com/openai/codex"
+  echo ""
+  echo "Alternatively, add the guidelines to your project:"
+  echo "  curl -sL $REPO_URL/$COMMAND_FILE > DOTLOTTIE.md"
+  exit 1
+else
+  printf "${GREEN}Done!${RESET} Installed for $INSTALLED tool(s).\n"
+  echo ""
+  echo "Usage:"
+  echo "  • Claude Code: /dotlottie or ask about dotLottie"
+  echo "  • Cursor: @dotlottie-guidelines in chat"
+  echo "  • Other tools: Reference dotlottie-guidelines in prompts"
+  echo ""
+  echo "Learn more: https://developers.lottiefiles.com/docs/dotlottie-player"
+fi


### PR DESCRIPTION
## Summary

Adds dotLottie implementation guidelines that can be installed as a skill/command for AI coding assistants.

### Install

```bash
curl -fsSL https://raw.githubusercontent.com/LottieFiles/dotlottie-web/main/guidelines/install.sh | bash
```

### Supported Tools

- Claude Code (`~/.claude/commands/`)
- Cursor (`~/.cursor/commands/`)
- OpenCode (`~/.config/opencode/command/`)
- Windsurf (`~/.codeium/windsurf/memories/`)
- Gemini CLI (`~/.gemini/commands/`)
- Codex CLI (`~/.codex/commands/`)

### Guidelines Cover

- Package selection (dotlottie-web vs dotlottie-react)
- Basic implementation patterns
- State machines for interactivity
- Theming with slots
- Markers & segments
- Performance best practices
- Common interaction patterns
- Debugging tips

### Inspiration

Inspired by [Vercel's Web Interface Guidelines](https://x.com/johnphamous/status/2010777566085595357) approach.

---

Once merged, we could also set up a redirect like `lottiefiles.com/dotlottie/install` → raw GitHub URL.