### PR TITLE
fix: restore dotlottie-svelte version to 0.8.15

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lottiefiles/dotlottie-svelte",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "type": "module",
   "description": "Svelte component wrapper around the dotlottie-web library to render Lottie and dotLottie animations",
   "repository": {


### PR DESCRIPTION
## Description

<!-- Summarize your changes. If this fixes an issue, include "Fixes #<issue>" below. -->

## Package(s) affected

- [ ] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [x] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [x] Tests have been added or updated
- [x] Changeset has been added (if applicable)
