### PR TITLE
fix: bundle lit sub-path exports in dotlottie-wc

### DIFF
--- a/.changeset/neat-buckets-tap.md
+++ b/.changeset/neat-buckets-tap.md
@@ -1,0 +1,6 @@
+---
+"@lottiefiles/dotlottie-wc": patch
+---
+
+fix: bundle lit sub-path exports to eliminate bare module specifiers in dist output
+  

--- a/packages/wc/tsdown.config.ts
+++ b/packages/wc/tsdown.config.ts
@@ -14,7 +14,10 @@ export default defineConfig({
   target: ['es2020'],
   tsconfig: 'tsconfig.build.json',
   // To ensure the ESM bundle is self-contained and usable via CDN
-  noExternal: Object.keys(pkg.dependencies),
+  // Use regex patterns to also match sub-path exports (e.g. lit/decorators.js)
+  noExternal: Object.keys(pkg.dependencies).map(
+    (dep) => new RegExp(`^${dep.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}($|/)`),
+  ),
   // rolldown-plugin-dts emits false MISSING_EXPORT warnings for type-only imports (e.g. Config interface).
   // tsdown defaults failOnWarn to true in CI, which would fail the build on these false positives.
   failOnWarn: false,


### PR DESCRIPTION
## Summary

- Fixed bare module specifier error (`Failed to resolve module specifier "lit/decorators.js"`) when loading `dotlottie-wc` dist output directly in a browser without a bundler
- Changed `noExternal` in `tsdown.config.ts` from exact string matching to regex patterns so sub-path exports like `lit/decorators.js` are also inlined into the bundle

## Test plan

- [x] Verified `pnpm run build` succeeds in `packages/wc`
- [x] Confirmed `lit/decorators.js` bare specifier no longer appears in dist JS files
- [x] Confirmed all dist imports use relative paths (`./...`)
- [x] Open `packages/wc/example.html` in browser and verify both `<dotlottie-wc>` and `<dotlottie-worker-wc>` render without console errors