### PR TITLE
fix(ci): upgrade setup-node to v6 and use Node LTS for OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
       - name: ⎔ Setup pnpm@v10
         uses: pnpm/action-setup@v4
 
-      - name: ⎔ Setup Node@v22
-        uses: actions/setup-node@v4
+      - name: ⎔ Setup Node@lts
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version: 22
+          node-version: lts/*
 
       - name: 📥 Install dependencies
         run: pnpm install
@@ -63,11 +63,11 @@ jobs:
       - name: ⎔ Setup pnpm@v10
         uses: pnpm/action-setup@v4
 
-      - name: ⎔ Setup Node@v22
-        uses: actions/setup-node@v4
+      - name: ⎔ Setup Node@lts
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version: 22
+          node-version: lts/*
 
       - name: 📥 Install dependencies
         run: pnpm install
@@ -96,11 +96,11 @@ jobs:
       - name: ⎔ Setup pnpm@v10
         uses: pnpm/action-setup@v4
 
-      - name: ⎔ Setup Node@v22
-        uses: actions/setup-node@v4
+      - name: ⎔ Setup Node@lts
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version: 22
+          node-version: lts/*
 
       - name: 📥 Install dependencies
         run: pnpm install
@@ -132,11 +132,11 @@ jobs:
       - name: ⎔ Setup pnpm@v10
         uses: pnpm/action-setup@v4
 
-      - name: ⎔ Setup Node@v22
-        uses: actions/setup-node@v4
+      - name: ⎔ Setup Node@lts
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version: 22
+          node-version: lts/*
 
       - name: 📥 Install dependencies
         run: pnpm install
@@ -210,11 +210,11 @@ jobs:
       - name: ⎔ Setup pnpm@v10
         uses: pnpm/action-setup@v4
 
-      - name: ⎔ Setup Node@v22
-        uses: actions/setup-node@v4
+      - name: ⎔ Setup Node@lts
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version: 22
+          node-version: lts/*
 
       - name: 📥 Install dependencies
         run: pnpm install

--- a/.github/workflows/deploy-viewer.yml
+++ b/.github/workflows/deploy-viewer.yml
@@ -33,11 +33,11 @@ jobs:
       - name: ⎔ Setup pnpm@v10
         uses: pnpm/action-setup@v4
 
-      - name: ⎔ Setup Node@v22
-        uses: actions/setup-node@v4
+      - name: ⎔ Setup Node@lts
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version: 22
+          node-version: lts/*
 
       - name: 📥 Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,11 @@ jobs:
       - name: ⎔ Setup pnpm@v10
         uses: pnpm/action-setup@v4
 
-      - name: ⎔ Setup Node@v22
-        uses: actions/setup-node@v4
+      - name: ⎔ Setup Node@lts
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version: 22
+          node-version: lts/*
 
       - name: 📥 Install dependencies
         run: pnpm install
@@ -85,11 +85,11 @@ jobs:
       - name: ⎔ Setup pnpm@v10
         uses: pnpm/action-setup@v4
 
-      - name: ⎔ Setup Node@v22
-        uses: actions/setup-node@v4
+      - name: ⎔ Setup Node@lts
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version: 22
+          node-version: lts/*
           registry-url: https://registry.npmjs.org
 
       - name: 📥 Install dependencies
@@ -127,11 +127,11 @@ jobs:
       - name: ⎔ Setup pnpm@v10
         uses: pnpm/action-setup@v4
 
-      - name: ⎔ Setup Node@v22
-        uses: actions/setup-node@v4
+      - name: ⎔ Setup Node@lts
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version: 22
+          node-version: lts/*
           registry-url: https://npm.pkg.github.com/
 
       - name: 📥 Install dependencies
@@ -167,11 +167,11 @@ jobs:
       - name: ⎔ Setup pnpm@v10
         uses: pnpm/action-setup@v4
 
-      - name: ⎔ Setup Node@v22
-        uses: actions/setup-node@v4
+      - name: ⎔ Setup Node@lts
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version: 22
+          node-version: lts/*
           registry-url: https://registry.npmjs.org
 
       - name: 📥 Install dependencies


### PR DESCRIPTION
## Description

Fixes npm publish E404 failures by upgrading `actions/setup-node` from v4 to v6 and switching from Node 22 to `lts/*`. 

`setup-node@v6` has built-in OIDC trusted publishing support, removing the need for the manual `npm install -g npm@latest` step (which was removed in #783) that previously caused runner corruption.

## Package(s) affected

None — CI-only change.

## Type of change

- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)