### PR TITLE
fix(web): guard destroy() against double-free when wasm cleanup throws

### DIFF
--- a/.changeset/fix-destroy-double-free-guard.md
+++ b/.changeset/fix-destroy-double-free-guard.md
@@ -1,0 +1,5 @@
+---
+"@lottiefiles/dotlottie-web": patch
+---
+
+Fix `Error: null pointer passed to rust` thrown from `DotLottie.destroy()` on iOS Safari 15.5. Make `destroy()` idempotent: null `_dotLottieCore` before invoking `free()`, and swallow wasm-side cleanup errors so they don't propagate into React error boundaries on unmount.

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -1221,9 +1221,18 @@ export class DotLottie {
 
     this._cleanupCanvas();
 
-    this._dotLottieCore?.free();
+    const core = this._dotLottieCore;
+
     this._dotLottieCore = null;
     this._context = null;
+
+    if (core) {
+      try {
+        core.free();
+      } catch (err) {
+        console.warn('[dotlottie-web] Error freeing wasm core during destroy:', err);
+      }
+    }
 
     this._eventManager.dispatch({
       type: 'destroy',

--- a/packages/web/tests/dotlottie.test.ts
+++ b/packages/web/tests/dotlottie.test.ts
@@ -587,6 +587,31 @@ describe.each([
       expect(onPlay).toHaveBeenCalledTimes(1);
       expect(onLoad).toHaveBeenCalledTimes(1);
     });
+
+    (isWorker ? test.skip : test)('destroy() is idempotent when free() throws', async () => {
+      const onReady = vi.fn();
+
+      dotLottie = new DotLottie({
+        canvas,
+        src,
+      });
+
+      dotLottie.addEventListener('ready', onReady);
+
+      await vi.waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+
+      const dotLottieCore = (dotLottie as DotLottieClass as any)._dotLottieCore as DotLottiePlayer;
+      const freeSpy = vi.spyOn(dotLottieCore, 'free').mockImplementation(() => {
+        throw new Error('null pointer passed to rust');
+      });
+
+      expect(() => dotLottie.destroy()).not.toThrow();
+      expect(freeSpy).toHaveBeenCalledTimes(1);
+
+      expect(() => dotLottie.destroy()).not.toThrow();
+      expect(freeSpy).toHaveBeenCalledTimes(1);
+      expect((dotLottie as DotLottieClass as any)._dotLottieCore).toBeNull();
+    });
   });
 
   (isWorker ? test.skip : test)('trigger renderError event when failed to render', async () => {


### PR DESCRIPTION
## Description

On iOS Safari 15.5 the wasm-side drop invoked from `DotLottiePlayerWasm.free()` can throw under memory pressure. The previous `destroy()` ordering called `free()` before nulling `_dotLottieCore`, so the throw left the field non-null and a subsequent `destroy()` (e.g. from React unmount after the animation loop traps) re-entered `free()` on a wrapper whose `__wbg_ptr` was already zeroed, raising the wasm-bindgen `"null pointer passed to rust"` panic into React's error boundary.

This change nulls `_dotLottieCore` before calling `free()` and wraps the call in try/catch so `destroy()` is idempotent and wasm cleanup errors don't propagate to consumers.

Fixes #819

## Package(s) affected

- [x] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [x] Tests have been added or updated
- [x] Changeset has been added (if applicable)