### PR TITLE
fix(viewer): dedupe react/react-dom to fix gh-pages useRef crash

### DIFF
--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -6,6 +6,9 @@ const config = defineConfig(({ mode }) => ({
   plugins: [react()],
   base: mode === 'development' ? '/' : '/dotlottie-web/',
   publicDir: '../../fixtures',
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
 }));
 
 export default config;


### PR DESCRIPTION
## Description

The deployed viewer at https://lottiefiles.github.io/dotlottie-web/ crashes on load with:

```
Uncaught TypeError: Cannot read properties of null (reading 'useRef')
    at react_production.useRef (index-Dr0v76ed.js:323:8556)
```

### Root cause

Two copies of React were being bundled into the production build:

- `apps/viewer` directly depends on `react@^19.2.3` → resolves to **react@19.1.1** in viewer's `node_modules`
- `packages/react` (the workspace `@lottiefiles/dotlottie-react`) declares `react: ^19` in devDeps → resolves independently to **react@19.2.3** under `packages/react/node_modules`

Because `@lottiefiles/dotlottie-react` is a symlinked workspace package, Vite's production resolver walks `node_modules` from the symlink target, picking up the local React copy. The viewer's own imports resolve to the other one. Both end up in the bundle.

In React 19, hooks dispatch through `ReactSharedInternals.H`, which is set by whichever React instance is currently rendering. Component code that resolves to the other instance reads `H = null` and crashes on the first hook call (`useRef`). Dev mode hides this because Vite's dependency optimizer dedupes more aggressively than the production Rollup pass.

### Fix

Add `resolve.dedupe: ['react', 'react-dom']` to `apps/viewer/vite.config.ts`. This forces Vite to resolve all `react`/`react-dom` imports — even those originating from symlinked workspace packages — to the single copy at the project root.

### Verification

Rebuilt locally and inspected the bundle:

| | Before | After |
|--|--|--|
| `react.production` string occurrences in main bundle | 6 | 3 |
| Main bundle size | 2,016,322 B | 2,004,209 B |

The 6 → 3 reduction is exactly consistent with eliminating one of two React copies (each contributes 3 occurrences: the `var react_production={}` declaration, the IIFE that assigns its methods, and the source-map comment).

## Package(s) affected

- [ ] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

(Affects only the internal `apps/viewer` build, not a published package.)

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)