### PR TITLE
chore(deps-dev): bump tsdown from 0.20.3 to 0.21.10 (4 of 5 packages)

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -77,7 +77,7 @@
     "@vitest/coverage-istanbul": "^4.0.18",
     "react": "^19",
     "react-dom": "^19",
-    "tsdown": "^0.20.3",
+    "tsdown": "^0.21.10",
     "typescript": "6.0.3",
     "vitest": "^4.0.18",
     "vitest-browser-react": "^2.0.5"

--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -13,8 +13,10 @@ const config: UserConfig = {
   platform: 'browser',
   target: ['es2020'],
   tsconfig: 'tsconfig.build.json',
-  external: ['react'],
+  deps: { neverBundle: ['react'] },
 };
+
+const cdnDeps = { neverBundle: ['react'], alwaysBundle: Object.keys(pkg.dependencies) };
 
 export default defineConfig([
   config,
@@ -22,7 +24,7 @@ export default defineConfig([
   {
     ...config,
     dts: false,
-    noExternal: Object.keys(pkg.dependencies),
+    deps: cdnDeps,
     outDir: 'dist/browser',
   },
   // WebGL
@@ -35,7 +37,7 @@ export default defineConfig([
     ...config,
     entry: { 'webgl/index': './src/webgl/index.tsx' },
     dts: false,
-    noExternal: Object.keys(pkg.dependencies),
+    deps: cdnDeps,
     outDir: 'dist/browser',
   },
   // WebGPU
@@ -48,7 +50,7 @@ export default defineConfig([
     ...config,
     entry: { 'webgpu/index': './src/webgpu/index.tsx' },
     dts: false,
-    noExternal: Object.keys(pkg.dependencies),
+    deps: cdnDeps,
     outDir: 'dist/browser',
   },
 ]);

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/node": "^25.6.0",
     "solid-js": "^1.9.10",
-    "tsdown": "^0.20.3",
+    "tsdown": "^0.21.10",
     "typescript": "6.0.3",
     "unplugin-solid": "^1.0.0"
   },

--- a/packages/solid/tsdown.config.ts
+++ b/packages/solid/tsdown.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   tsconfig: 'tsconfig.build.json',
-  external: ['solid-js'],
+  deps: { neverBundle: ['solid-js'] },
   fixedExtension: false,
   plugins: [solid()],
 });

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@vue/runtime-dom": "^3.4.6",
     "@vue/tsconfig": "^0.9.1",
-    "tsdown": "^0.20.3",
+    "tsdown": "^0.21.10",
     "typescript": "6.0.3"
   },
   "publishConfig": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -90,7 +90,7 @@
     "@vitest/coverage-istanbul": "^4.0.18",
     "@webgpu/types": "^0.1.69",
     "esbuild": "^0.28.0",
-    "tsdown": "^0.20.3",
+    "tsdown": "^0.21.10",
     "typescript": "6.0.3",
     "vitest": "^4.0.18"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,8 +408,8 @@ importers:
         specifier: ^19
         version: 19.1.1(react@19.1.1)
       tsdown:
-        specifier: ^0.20.3
-        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(publint@0.3.18)(typescript@6.0.3)
+        specifier: ^0.21.10
+        version: 0.21.10(publint@0.3.18)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -433,8 +433,8 @@ importers:
         specifier: ^1.9.10
         version: 1.9.11
       tsdown:
-        specifier: ^0.20.3
-        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(publint@0.3.18)(typescript@6.0.3)
+        specifier: ^0.21.10
+        version: 0.21.10(publint@0.3.18)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -498,8 +498,8 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1(typescript@6.0.3)(vue@3.5.16(typescript@6.0.3))
       tsdown:
-        specifier: ^0.20.3
-        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(publint@0.3.18)(typescript@6.0.3)
+        specifier: ^0.21.10
+        version: 0.21.10(publint@0.3.18)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -553,8 +553,8 @@ importers:
         specifier: ^0.28.0
         version: 0.28.0
       tsdown:
-        specifier: ^0.20.3
-        version: 0.20.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(publint@0.3.18)(typescript@6.0.3)
+        specifier: ^0.21.10
+        version: 0.21.10(publint@0.3.18)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -606,6 +606,10 @@ packages:
 
   '@babel/generator@8.0.0-rc.2':
     resolution: {integrity: sha512-oCQ1IKPwkzCeJzAPb7Fv8rQ9k5+1sG8mf2uoHiMInPYvkRfrDJxbTIbH51U+jstlkghus0vAi3EBvkfvEsYNLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@babel/generator@8.0.0-rc.3':
+    resolution: {integrity: sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-compilation-targets@7.27.2':
@@ -3530,6 +3534,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -4679,6 +4687,10 @@ packages:
 
   import-without-cache@0.2.5:
     resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
+    engines: {node: '>=20.19.0'}
+
+  import-without-cache@0.3.3:
+    resolution: {integrity: sha512-bDxwDdF04gm550DfZHgffvlX+9kUlcz32UD0AeBTmVPFiWkrexF2XVmiuFFbDhiFuP8fQkrkvI2KdSNPYWAXkQ==}
     engines: {node: '>=20.19.0'}
 
   imurmurhash@0.1.4:
@@ -6341,6 +6353,25 @@ packages:
       vue-tsc:
         optional: true
 
+  rolldown-plugin-dts@0.23.2:
+    resolution: {integrity: sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@ts-macro/tsc': ^0.3.6
+      '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
+      rolldown: ^1.0.0-rc.12
+      typescript: ^5.0.0 || ^6.0.0
+      vue-tsc: ~3.2.0
+    peerDependenciesMeta:
+      '@ts-macro/tsc':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6876,6 +6907,34 @@ packages:
       typescript:
         optional: true
       unplugin-lightningcss:
+        optional: true
+      unplugin-unused:
+        optional: true
+
+  tsdown@0.21.10:
+    resolution: {integrity: sha512-3wk73yBhZe/wX7REqSdivNQ84TDs1mJ+IlnzrrEREP70xlJ/AEIzqaI04l/TzMKVIdkTdC3CPaADn2Lk/0SkdA==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@tsdown/css': 0.21.10
+      '@tsdown/exe': 0.21.10
+      '@vitejs/devtools': '*'
+      publint: ^0.3.0
+      typescript: ^5.0.0 || ^6.0.0
+      unplugin-unused: ^0.5.0
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@tsdown/css':
+        optional: true
+      '@tsdown/exe':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      publint:
+        optional: true
+      typescript:
         optional: true
       unplugin-unused:
         optional: true
@@ -7576,6 +7635,15 @@ snapshots:
       jsesc: 3.1.0
 
   '@babel/generator@8.0.0-rc.2':
+    dependencies:
+      '@babel/parser': 8.0.0-rc.3
+      '@babel/types': 8.0.0-rc.3
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
+  '@babel/generator@8.0.0-rc.3':
     dependencies:
       '@babel/parser': 8.0.0-rc.3
       '@babel/types': 8.0.0-rc.3
@@ -10428,6 +10496,8 @@ snapshots:
 
   cac@6.7.14: {}
 
+  cac@7.0.0: {}
+
   callsites@3.1.0: {}
 
   camelcase-css@2.0.1: {}
@@ -11715,6 +11785,8 @@ snapshots:
   import-meta-resolve@4.1.0: {}
 
   import-without-cache@0.2.5: {}
+
+  import-without-cache@0.3.3: {}
 
   imurmurhash@0.1.4: {}
 
@@ -13961,6 +14033,24 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@6.0.3):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.3
+      '@babel/helper-validator-identifier': 8.0.0-rc.3
+      '@babel/parser': 8.0.0-rc.3
+      '@babel/types': 8.0.0-rc.3
+      ast-kit: 3.0.0-beta.1
+      birpc: 4.0.0
+      dts-resolver: 2.1.3
+      get-tsconfig: 4.14.0
+      obug: 2.1.1
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.17
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rolldown@1.0.0-rc.17:
     dependencies:
       '@oxc-project/types': 0.127.0
@@ -14659,6 +14749,34 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - synckit
+      - vue-tsc
+
+  tsdown@0.21.10(publint@0.3.18)(typescript@6.0.3):
+    dependencies:
+      ansis: 4.2.0
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.0
+      hookable: 6.1.1
+      import-without-cache: 0.3.3
+      obug: 2.1.1
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.17
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@6.0.3)
+      semver: 7.7.4
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      unrun: 0.2.37
+    optionalDependencies:
+      publint: 0.3.18
+      typescript: 6.0.3
+    transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
       - oxc-resolver


### PR DESCRIPTION
## Description

Upgrades \`tsdown\` from \`^0.20.3\` to \`^0.21.10\` across the workspace. Closes the matching Dependabot PRs in a single change.

While here, migrates the deprecated \`external\` / \`noExternal\` options to the new \`deps.neverBundle\` / \`deps.alwaysBundle\` form (renamed in \`tsdown\` 0.21).

**\`packages/wc\` is intentionally held back at \`0.20.3\`.** In 0.21.x \`rolldown-plugin-dts\` started emitting \`MISSING_EXPORT\` as a fatal error during d.ts bundling — this fires on type-only imports of the \`Config\` interface from \`@lottiefiles/dotlottie-web\` (the existing \`failOnWarn: false\` workaround was for the prior warning behavior). I'd rather not block the rest of the upgrade on chasing that down; will follow up separately.

Closes #822 (web), #821 (vue), #823 (solid), #825 (react). Leaves #824 (wc) open pending the follow-up.

## Package(s) affected

- [x] \`@lottiefiles/dotlottie-web\` (core) — devDep only, no published behavior change
- [x] \`@lottiefiles/dotlottie-react\` — devDep only
- [x] \`@lottiefiles/dotlottie-vue\` — devDep only
- [ ] \`@lottiefiles/dotlottie-svelte\`
- [x] \`@lottiefiles/dotlottie-solid\` — devDep only
- [ ] \`@lottiefiles/dotlottie-wc\` — held back at 0.20.3

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally — \`pnpm build\`, \`pnpm type-check\`, and \`pnpm lint\` all pass
- [ ] Tests have been added or updated — N/A, dev-dep bump
- [ ] Changeset has been added — N/A, no published-output change