### PR TITLE
fix(examples/web): point wasm import at packages/web/src/core

### DIFF
--- a/examples/web/src/main.ts
+++ b/examples/web/src/main.ts
@@ -5,7 +5,7 @@ import type { Fit, Mode } from '@lottiefiles/dotlottie-web';
 // import { DotLottieWorker as DotLottie } from '@lottiefiles/dotlottie-web';
 import { DotLottie } from '@lottiefiles/dotlottie-web';
 
-import wasmUrl from '../../../packages/web/dist/dotlottie-player.wasm?url';
+import wasmUrl from '../../../packages/web/src/core/dotlottie-player.wasm?url';
 
 const app = document.getElementById('app') as HTMLDivElement;
 
@@ -145,7 +145,7 @@ app.innerHTML = `
 /**
  * This is only required for testing the local version of the renderer
  */
-DotLottie.setWasmUrl(`${baseUrl}${wasmUrl}`);
+DotLottie.setWasmUrl(wasmUrl);
 
 /**
  * Load all canvas elements with data-src attribute


### PR DESCRIPTION
## Description

The \`examples/web\` entrypoint imported the canvas wasm from \`packages/web/dist/dotlottie-player.wasm?url\`, which only exists after a \`pnpm --filter @lottiefiles/dotlottie-web build\`, and then concatenated \`baseUrl\` with the resolved URL — producing a double-slash URL like \`http://localhost:3000//assets/...\`.

Switch the import to \`packages/web/src/core/dotlottie-player.wasm?url\` and pass it straight to \`DotLottie.setWasmUrl\`, matching what every other browser example (\`next\`, \`react\`, \`solid\`, \`vue\`, \`wc\`) already does. The example now works without a prior package build, and Vite's \`?url\` import resolves correctly on its own.

## Package(s) affected

- [ ] \`@lottiefiles/dotlottie-web\` (core)
- [ ] \`@lottiefiles/dotlottie-react\`
- [ ] \`@lottiefiles/dotlottie-vue\`
- [ ] \`@lottiefiles/dotlottie-svelte\`
- [ ] \`@lottiefiles/dotlottie-solid\`
- [ ] \`@lottiefiles/dotlottie-wc\`

(Affects \`examples/web\` only — not a published package.)

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally — \`pnpm --filter web-example build\` produces \`dist/assets/dotlottie-player-*.wasm\` and the JS resolves \`setWasmUrl\` with a single-slash URL
- [ ] Tests have been added or updated — N/A, examples-only fix
- [ ] Changeset has been added — N/A, no published-output change