### PR TITLE
fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,7 +4,7 @@ on:
     - cron: '30 1 * * *'
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
Potential fix for [https://github.com/LottieFiles/dotlottie-web/security/code-scanning/23](https://github.com/LottieFiles/dotlottie-web/security/code-scanning/23)

Add an explicit `permissions` block in `.github/workflows/stale.yml` so the workflow documents and enforces least privilege regardless of repo/org defaults.

Best fix here (without changing behavior): set workflow-level permissions to only what `actions/stale@v9` needs:
- `contents: write`
- `issues: write`
- `pull-requests: write`

Place this block near the top-level keys (right after `on:` section is clean and conventional). No imports, methods, or other files are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
