### PR TITLE
fix(ci): scope GPR registry to @lottiefiles for publish only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,15 +132,22 @@ jobs:
         with:
           cache: pnpm
           node-version: lts/*
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
 
       - name: 📥 Install dependencies
         run: pnpm install
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🏗 Build packages
         run: pnpm build:packages
+
+      - name: ⎔ Configure GPR registry for @lottiefiles scope
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo "@lottiefiles:registry=https://npm.pkg.github.com/"
+            echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}"
+          } >> .npmrc
 
       - name: 🚀 Publish to GitHub Packages
         run: pnpm changeset publish


### PR DESCRIPTION
## Description

The `gpr-release` job in `.github/workflows/release.yml` set `registry-url: https://npm.pkg.github.com/` on `actions/setup-node` **without** a `scope` input. With no scope, `actions/setup-node` writes a global `registry=...` line to `~/.npmrc`, which routes every `pnpm install` package fetch through GitHub Packages — including third-party deps and internal `@lottiefiles/*` dev dependencies that only live on npmjs.

That caused the most recent release to fail at install:

```
ERR_PNPM_FETCH_404  GET https://npm.pkg.github.com/@lottiefiles/commitlint-config/-/commitlint-config-2.0.0.tgz: Not Found - 404
```

Failing run: https://github.com/LottieFiles/dotlottie-web/actions/runs/25301433588/job/74169461287

### Why it didn't fail until now

The misconfig has been latent for weeks, masked by `actions/setup-node`'s `cache: pnpm` store hits:

| Run | Output |
| --- | --- |
| 2026-04-14 ✓ | `resolved 1396, reused 1392, downloaded 0, added 1396` (cache hit, no real fetch) |
| 2026-05-04 ✗ | `resolved 1400, reused 0, downloaded 125, added 125` (cache miss → real fetch → 404) |

Recent dependency bumps (Svelte 5 #722, tsdown #832, Svelte deps #834, Dependabot consolidation #830) changed `pnpm-lock.yaml`, invalidating the lockfile-keyed pnpm store cache. With no cache hit, pnpm had to actually fetch from the registry — surfacing the bug.

### Fix

Install from npmjs (the default), then append the GPR scope mapping to `.npmrc` **only before `changeset publish` runs**:

- Third-party + dev deps resolve from npmjs as expected.
- `@lottiefiles` scoped publishes still go to GitHub Packages, authenticated via `GITHUB_TOKEN`.
- The token is passed through `env:` rather than being expanded directly into the shell command body, keeping secrets out of the script source.

### Verification

Verified end-to-end on a temporary workflow run against this branch (workflow file dropped before merge):

| Check | Output | Conclusion |
|---|---|---|
| `pnpm install` (cold cache) | `resolved 1400, reused 0, downloaded 1394, added 1400, done` | Full cold-cache install of all 1400 packages with no 404 — same conditions that broke run [25301433588](https://github.com/LottieFiles/dotlottie-web/actions/runs/25301433588). |
| `npm whoami --registry=https://npm.pkg.github.com/` | `github-actions[bot]` | GPR auth via the appended `.npmrc` works. |

## Package(s) affected

- [ ] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

(CI-only change — no published package contents change.)

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)

## Follow-up

After this lands on `main`, re-running the `gpr-release` job for failed run [25301433588](https://github.com/LottieFiles/dotlottie-web/actions/runs/25301433588) will pick up the fixed workflow from `main` and complete the GPR publish for the version that already shipped to npm.