### PR TITLE
ci(release): manual trigger + always run GPR alongside NPM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: release
@@ -16,6 +17,7 @@ jobs:
   validate:
     name: Validate
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
 
     permissions:
       contents: read
@@ -111,7 +113,15 @@ jobs:
     name: GPR Release
     needs: npm-release
     runs-on: ubuntu-latest
-    if: needs.npm-release.outputs.published == 'true'
+    if: |
+      always() &&
+      github.repository == 'LottieFiles/dotlottie-web' &&
+      needs.npm-release.result != 'cancelled' &&
+      (
+        needs.npm-release.outputs.published == 'true' ||
+        needs.npm-release.result == 'failure' ||
+        github.event_name == 'workflow_dispatch'
+      )
 
     permissions:
       contents: read


### PR DESCRIPTION
## Description

Follow-up to #836. Makes the GPR release more resilient and adds a manual escape hatch.

**What changes**

1. `workflow_dispatch:` trigger added to `release.yml` so the release pipeline can be manually fired from the Actions tab.
2. `validate` job is skipped on `workflow_dispatch` (main is already proven good — saves time during recovery).
3. `gpr-release` no longer skips when its sibling fails. New gate:

   ```yaml
   if: |
     always() &&
     github.repository == 'LottieFiles/dotlottie-web' &&
     needs.npm-release.result != 'cancelled' &&
     (
       needs.npm-release.outputs.published == 'true' ||
       needs.npm-release.result == 'failure' ||
       github.event_name == 'workflow_dispatch'
     )
   ```

**Why**

- Currently, if `npm-release` errors midway, `gpr-release` is skipped via the `needs:` cascade — so the two registries can drift. We saw exactly this happen in the run that motivated #836.
- There was also no way to manually re-run `gpr-release` against the current `main` without authoring a fake changeset just to flip `published == 'true'`.

**Behavior matrix**

| Trigger | npm-release | gpr-release | jsr-release |
|---|---|---|---|
| Push to main, version PR merged, npm OK | runs, `published='true'` | runs ✅ | runs ✅ |
| Push to main, no version bumps (changeset PR update) | runs, `published='false'` | skips ✅ | skips ✅ |
| Push to main, npm publish fails | fails | runs ✅ | skips (cascade) |
| Push to main, run cancelled | cancelled | skips ✅ | skips |
| `workflow_dispatch` | skipped (validate gate) | runs ✅ | skips |

`pnpm changeset publish` is idempotent against the registry — packages whose version already exists on GPR are silently skipped. So running on `workflow_dispatch` or after a partial npm failure is safe.

**Recovery plan**

After this merges, trigger the workflow manually from the Actions tab to publish `0.50.6` (and any earlier missed versions) to GPR — no fresh changeset needed.

## Package(s) affected

- [ ] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

(CI-only change — no package code touched, no changeset needed.)

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally (`actionlint` clean; condition matrix walked)
- [ ] Tests have been added or updated (n/a — workflow logic; will validate on first auto run + manual dispatch)
- [ ] Changeset has been added (n/a — CI-only)