### PR TITLE
fix(svelte): remove orphaned .npmrc that broke GPR scope routing

### DIFF
--- a/packages/svelte/.npmrc
+++ b/packages/svelte/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true


### PR DESCRIPTION
## Description

Follow-up to #836 / #837. Removes `packages/svelte/.npmrc`, a single-line orphan (`engine-strict=true`) left over from the original DotLottieSvelte feature commit (#135).

**Why it matters**

The manual `workflow_dispatch` GPR run on 2026-05-04 ([run 25302931643](https://github.com/LottieFiles/dotlottie-web/actions/runs/25302931643)) published 5 of 6 packages to GPR and failed on `@lottiefiles/dotlottie-svelte` with:

```
npm error You cannot publish over the previously published versions: 0.10.0.
```

That error came from **npmjs.org, not GPR.** Mechanism:

1. `@changesets/cli` spawns `pnpm publish` with `cwd` set to the **package directory** (see `cli/dist/changesets-cli.cjs.js:771`).
2. pnpm's `.npmrc` resolution stops at the closest file. With `packages/svelte/.npmrc` present, pnpm reads only that one as project config.
3. The workspace-root `.npmrc` — which is where the GPR job writes the `@lottiefiles -> https://npm.pkg.github.com/` scope mapping at runtime — is **not picked up**.
4. Without scope routing, `@lottiefiles/dotlottie-svelte` falls back to the default registry (npmjs). Version `0.10.0` is already there → publish rejected.

The other five packages have no local `.npmrc`, so pnpm walks up to the workspace root, picks up the GPR mapping, and publishes correctly.

**Why removal is safe**

- File contents: `engine-strict=true` (single line, nothing else).
- `packages/svelte/package.json` has **no** `engines` field, so `engine-strict=true` had nothing to enforce. It was dead config.
- Adding it back at the workspace level would re-enable strict engine checks for all packages — out of scope here, but easy to do later if needed.

**Recovery**

After merge, re-trigger the Release workflow via `workflow_dispatch` (added in #837). Svelte will route to GPR this time and `0.10.0` will publish there. (The 5 packages from the earlier run already landed; `pnpm changeset publish` is idempotent and will skip them.)

## Package(s) affected

- [ ] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [x] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

(Affects publish behavior of the svelte package only — no runtime code touched.)

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally (file confirmed orphaned: no `engines` field on the package; no other consumers of the file)
- [ ] Tests have been added or updated (n/a — registry routing only)
- [ ] Changeset has been added (n/a — no shipped code or API change)