### PR TITLE
fix(web): fall back to buffered WASM instantiation when streaming fails

### DIFF
--- a/.changeset/wkwebview-streaming-fallback.md
+++ b/.changeset/wkwebview-streaming-fallback.md
@@ -1,0 +1,5 @@
+---
+"@lottiefiles/dotlottie-web": patch
+---
+
+Fall back to buffered `WebAssembly.instantiate` when streaming instantiation fails on both CDN URLs. Some iOS WKWebView builds reject `WebAssembly.instantiateStreaming` for otherwise valid `Response` objects, which previously surfaced as `WASM loading failed from all sources.` and a blank canvas. The loader now retries by fetching the bytes itself and passing an `ArrayBuffer` to `init`, bypassing the streaming code path.

--- a/packages/web/src/wasm-loader.ts
+++ b/packages/web/src/wasm-loader.ts
@@ -28,38 +28,42 @@ export function createWasmLoader(initFn: WasmInitFn, primaryUrl: string, backupU
   return {
     load(): Promise<void> {
       if (!initPromise) {
+        // Snapshot URLs so a concurrent setWasmUrl() can't shift them mid-attempt.
+        const primary = wasmUrl;
+        const backup = backupUrl;
+
         initPromise = (async () => {
           let primaryError: unknown;
           let backupError: unknown;
 
           try {
-            await initFromUrl(wasmUrl);
+            await initFromUrl(primary);
             return;
           } catch (err) {
             primaryError = err;
-            console.warn(`Primary WASM load failed from ${wasmUrl}: ${(err as Error).message}`);
-            console.warn(`Attempting to load WASM from backup URL: ${backupUrl}`);
+            console.warn(`Primary WASM load failed from ${primary}: ${(err as Error).message}`);
+            console.warn(`Attempting to load WASM from backup URL: ${backup}`);
           }
 
           try {
-            await initFromUrl(backupUrl);
+            await initFromUrl(backup);
             return;
           } catch (err) {
             backupError = err;
-            console.warn(`Backup WASM load failed from ${backupUrl}: ${(err as Error).message}`);
+            console.warn(`Backup WASM load failed from ${backup}: ${(err as Error).message}`);
           }
 
           console.warn('Retrying WASM load with buffered instantiation');
 
           try {
-            await initFromBytes(wasmUrl);
+            await initFromBytes(primary);
             return;
           } catch (err) {
-            console.warn(`Buffered WASM load from ${wasmUrl} failed: ${(err as Error).message}`);
+            console.warn(`Buffered WASM load from ${primary} failed: ${(err as Error).message}`);
           }
 
           try {
-            await initFromBytes(backupUrl);
+            await initFromBytes(backup);
             return;
           } catch (err) {
             console.error(`Primary WASM URL failed: ${(primaryError as Error).message}`);

--- a/packages/web/src/wasm-loader.ts
+++ b/packages/web/src/wasm-loader.ts
@@ -1,27 +1,74 @@
-type WasmInitFn = (options: { module_or_path: string }) => Promise<unknown>;
+type WasmInitInput = string | BufferSource;
+type WasmInitFn = (options: { module_or_path: WasmInitInput }) => Promise<unknown>;
 
 export function createWasmLoader(initFn: WasmInitFn, primaryUrl: string, backupUrl: string) {
   let initPromise: Promise<void> | null = null;
   let wasmUrl = primaryUrl;
 
+  async function initFromUrl(url: string): Promise<void> {
+    await initFn({ module_or_path: url });
+  }
+
+  // Some environments (notably certain iOS WKWebView builds) reject
+  // WebAssembly.instantiateStreaming even for otherwise valid Response objects.
+  // Fetching bytes ourselves and passing a BufferSource to wasm-bindgen's init
+  // skips its streaming code path entirely.
+  async function initFromBytes(url: string): Promise<void> {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`fetch ${url} responded with ${response.status} ${response.statusText}`);
+    }
+
+    const buffer = await response.arrayBuffer();
+
+    await initFn({ module_or_path: buffer });
+  }
+
   return {
     load(): Promise<void> {
       if (!initPromise) {
-        initPromise = initFn({ module_or_path: wasmUrl })
-          .then(() => undefined)
-          .catch(async (initialError: unknown): Promise<void> => {
-            console.warn(`Primary WASM load failed from ${wasmUrl}: ${(initialError as Error).message}`);
-            console.warn(`Attempting to load WASM from backup URL: ${backupUrl}`);
+        initPromise = (async () => {
+          let primaryError: unknown;
+          let backupError: unknown;
 
-            try {
-              await initFn({ module_or_path: backupUrl });
-            } catch (backupError) {
-              console.error(`Primary WASM URL failed: ${(initialError as Error).message}`);
-              console.error(`Backup WASM URL failed: ${(backupError as Error).message}`);
-              initPromise = null;
-              throw new Error('WASM loading failed from all sources.');
-            }
-          });
+          try {
+            await initFromUrl(wasmUrl);
+            return;
+          } catch (err) {
+            primaryError = err;
+            console.warn(`Primary WASM load failed from ${wasmUrl}: ${(err as Error).message}`);
+            console.warn(`Attempting to load WASM from backup URL: ${backupUrl}`);
+          }
+
+          try {
+            await initFromUrl(backupUrl);
+            return;
+          } catch (err) {
+            backupError = err;
+            console.warn(`Backup WASM load failed from ${backupUrl}: ${(err as Error).message}`);
+          }
+
+          console.warn('Retrying WASM load with buffered instantiation');
+
+          try {
+            await initFromBytes(wasmUrl);
+            return;
+          } catch (err) {
+            console.warn(`Buffered WASM load from ${wasmUrl} failed: ${(err as Error).message}`);
+          }
+
+          try {
+            await initFromBytes(backupUrl);
+            return;
+          } catch (err) {
+            console.error(`Primary WASM URL failed: ${(primaryError as Error).message}`);
+            console.error(`Backup WASM URL failed: ${(backupError as Error).message}`);
+            console.error(`Buffered fallback failed: ${(err as Error).message}`);
+            initPromise = null;
+            throw new Error('WASM loading failed from all sources.');
+          }
+        })();
       }
 
       return initPromise;

--- a/packages/web/tests/wasm-loader.test.ts
+++ b/packages/web/tests/wasm-loader.test.ts
@@ -6,16 +6,25 @@ const BACKUP = 'https://backup.example.com/player.wasm';
 
 type WasmInitFn = Parameters<typeof createWasmLoader>[0];
 
+const wasmBytes = () => new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]).buffer;
+
+const okResponse = (): Response => new Response(wasmBytes(), { status: 200, statusText: 'OK' });
+const notOkResponse = (status = 404, statusText = 'Not Found'): Response => new Response(null, { status, statusText });
+
 describe('createWasmLoader', () => {
   let initFn: Mock<WasmInitFn>;
+  let fetchMock: Mock<typeof fetch>;
 
   beforeEach(() => {
     initFn = vi.fn<WasmInitFn>();
+    fetchMock = vi.fn<typeof fetch>().mockRejectedValue(new Error('fetch not stubbed'));
+    vi.stubGlobal('fetch', fetchMock);
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -25,6 +34,7 @@ describe('createWasmLoader', () => {
     await expect(loader.load()).resolves.toBeUndefined();
     expect(initFn).toHaveBeenCalledTimes(1);
     expect(initFn).toHaveBeenCalledWith({ module_or_path: PRIMARY });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('deduplicates concurrent load() calls', async () => {
@@ -34,7 +44,7 @@ describe('createWasmLoader', () => {
     expect(initFn).toHaveBeenCalledTimes(1);
   });
 
-  it('falls back to backup URL when primary fails', async () => {
+  it('falls back to backup URL when primary streaming fails', async () => {
     initFn.mockRejectedValueOnce(new Error('primary-fail'));
     initFn.mockResolvedValueOnce(undefined);
     const loader = createWasmLoader(initFn, PRIMARY, BACKUP);
@@ -42,25 +52,88 @@ describe('createWasmLoader', () => {
     expect(initFn).toHaveBeenCalledTimes(2);
     expect(initFn).toHaveBeenNthCalledWith(1, { module_or_path: PRIMARY });
     expect(initFn).toHaveBeenNthCalledWith(2, { module_or_path: BACKUP });
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(console.warn).toHaveBeenCalled();
   });
 
-  it('rejects when both URLs fail', async () => {
-    initFn.mockRejectedValue(new Error('fail'));
+  it('falls back to buffered primary load when both streaming attempts fail', async () => {
+    initFn.mockRejectedValueOnce(new Error('primary-stream'));
+    initFn.mockRejectedValueOnce(new Error('backup-stream'));
+    initFn.mockResolvedValueOnce(undefined);
+    fetchMock.mockResolvedValueOnce(okResponse());
+
+    const loader = createWasmLoader(initFn, PRIMARY, BACKUP);
+    await expect(loader.load()).resolves.toBeUndefined();
+
+    expect(initFn).toHaveBeenCalledTimes(3);
+    expect(initFn).toHaveBeenNthCalledWith(1, { module_or_path: PRIMARY });
+    expect(initFn).toHaveBeenNthCalledWith(2, { module_or_path: BACKUP });
+    expect(initFn).toHaveBeenNthCalledWith(3, { module_or_path: expect.any(ArrayBuffer) });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(PRIMARY);
+  });
+
+  it('falls back to buffered backup load when buffered primary also fails', async () => {
+    initFn.mockRejectedValueOnce(new Error('primary-stream'));
+    initFn.mockRejectedValueOnce(new Error('backup-stream'));
+    initFn.mockRejectedValueOnce(new Error('primary-buffer-instantiate'));
+    initFn.mockResolvedValueOnce(undefined);
+    fetchMock.mockResolvedValueOnce(okResponse());
+    fetchMock.mockResolvedValueOnce(okResponse());
+
+    const loader = createWasmLoader(initFn, PRIMARY, BACKUP);
+    await expect(loader.load()).resolves.toBeUndefined();
+
+    expect(initFn).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, PRIMARY);
+    expect(fetchMock).toHaveBeenNthCalledWith(2, BACKUP);
+  });
+
+  it('treats non-ok HTTP responses as buffer fetch failures', async () => {
+    initFn.mockRejectedValueOnce(new Error('primary-stream'));
+    initFn.mockRejectedValueOnce(new Error('backup-stream'));
+    initFn.mockResolvedValueOnce(undefined);
+    fetchMock.mockResolvedValueOnce(notOkResponse(404));
+    fetchMock.mockResolvedValueOnce(okResponse());
+
+    const loader = createWasmLoader(initFn, PRIMARY, BACKUP);
+    await expect(loader.load()).resolves.toBeUndefined();
+
+    expect(initFn).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // initFn was only called for streaming primary, streaming backup, and buffered backup
+    // — buffered primary was rejected at the fetch layer before reaching initFn
+    expect(initFn).toHaveBeenNthCalledWith(3, { module_or_path: expect.any(ArrayBuffer) });
+  });
+
+  it('rejects when streaming and buffered loads all fail', async () => {
+    initFn.mockRejectedValue(new Error('init-fail'));
+    fetchMock.mockRejectedValue(new Error('network-fail'));
+
     const loader = createWasmLoader(initFn, PRIMARY, BACKUP);
     await expect(loader.load()).rejects.toThrow('WASM loading failed from all sources.');
-    expect(console.error).toHaveBeenCalledTimes(2);
+
+    expect(initFn).toHaveBeenCalledTimes(2); // streaming primary + backup; buffer paths fail at fetch
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(console.error).toHaveBeenCalledTimes(3);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('init-fail'));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('network-fail'));
   });
 
   it('resets initPromise after total failure so next load() retries', async () => {
     initFn.mockRejectedValue(new Error('fail'));
+    fetchMock.mockRejectedValue(new Error('network-fail'));
+
     const loader = createWasmLoader(initFn, PRIMARY, BACKUP);
     await expect(loader.load()).rejects.toThrow();
-    // Second call must invoke initFn again (not return stale rejection)
+
+    initFn.mockReset();
+    fetchMock.mockReset();
     initFn.mockResolvedValue(undefined);
+
     await expect(loader.load()).resolves.toBeUndefined();
-    // initFn: 2 calls for first attempt (primary + backup) + 1 for second attempt
-    expect(initFn).toHaveBeenCalledTimes(3);
+    expect(initFn).toHaveBeenCalledTimes(1); // streaming primary succeeds on retry
   });
 
   it('setWasmUrl() with a new URL resets the loader', async () => {
@@ -78,9 +151,9 @@ describe('createWasmLoader', () => {
     initFn.mockResolvedValue(undefined);
     const loader = createWasmLoader(initFn, PRIMARY, BACKUP);
     await loader.load();
-    loader.setWasmUrl(PRIMARY); // same URL — should not reset
+    loader.setWasmUrl(PRIMARY);
     await loader.load();
-    expect(initFn).toHaveBeenCalledTimes(1); // still uses cached promise
+    expect(initFn).toHaveBeenCalledTimes(1);
   });
 
   it('logs warn with primary URL and backup notice on primary failure', async () => {
@@ -92,14 +165,16 @@ describe('createWasmLoader', () => {
     expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(BACKUP));
   });
 
-  it('logs error for both primary and backup failures on total failure', async () => {
-    const primaryError = new Error('primary-err');
-    const backupError = new Error('backup-err');
-    initFn.mockRejectedValueOnce(primaryError);
-    initFn.mockRejectedValueOnce(backupError);
+  it('logs final errors for primary, backup, and buffered failure', async () => {
+    initFn.mockRejectedValueOnce(new Error('primary-err'));
+    initFn.mockRejectedValueOnce(new Error('backup-err'));
+    fetchMock.mockRejectedValue(new Error('buffered-err'));
+
     const loader = createWasmLoader(initFn, PRIMARY, BACKUP);
     await expect(loader.load()).rejects.toThrow();
+
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('primary-err'));
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('backup-err'));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('buffered-err'));
   });
 });

--- a/packages/web/tests/wasm-loader.test.ts
+++ b/packages/web/tests/wasm-loader.test.ts
@@ -136,6 +136,25 @@ describe('createWasmLoader', () => {
     expect(initFn).toHaveBeenCalledTimes(1); // streaming primary succeeds on retry
   });
 
+  it('snapshots URLs at load() start so mid-flight setWasmUrl does not redirect retries', async () => {
+    initFn.mockRejectedValueOnce(new Error('primary-stream'));
+    initFn.mockRejectedValueOnce(new Error('backup-stream'));
+    initFn.mockResolvedValueOnce(undefined);
+    fetchMock.mockResolvedValueOnce(okResponse());
+
+    const loader = createWasmLoader(initFn, PRIMARY, BACKUP);
+    const loadPromise = loader.load();
+
+    // Concurrent caller mutates the URL while the IIFE is suspended on its first await.
+    loader.setWasmUrl('https://changed.example.com/player.wasm');
+
+    await expect(loadPromise).resolves.toBeUndefined();
+
+    // Buffered fallback must use the URL captured at load() start, not the changed one.
+    expect(fetchMock).toHaveBeenCalledWith(PRIMARY);
+    expect(fetchMock).not.toHaveBeenCalledWith(expect.stringContaining('changed'));
+  });
+
   it('setWasmUrl() with a new URL resets the loader', async () => {
     initFn.mockResolvedValue(undefined);
     const loader = createWasmLoader(initFn, PRIMARY, BACKUP);

--- a/packages/web/tests/wasm-loader.test.ts
+++ b/packages/web/tests/wasm-loader.test.ts
@@ -116,6 +116,7 @@ describe('createWasmLoader', () => {
 
     expect(initFn).toHaveBeenCalledTimes(2); // streaming primary + backup; buffer paths fail at fetch
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    // 3 errors at the final-failure path: primary streaming + backup streaming + last buffered attempt
     expect(console.error).toHaveBeenCalledTimes(3);
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('init-fail'));
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('network-fail'));


### PR DESCRIPTION
## Description

Some iOS WKWebView builds reject `WebAssembly.instantiateStreaming` for otherwise valid `Response` objects (JSC throws `TypeError: first argument must be an Response or Promise for Response`). Because the wasm-bindgen loader only falls back to `arrayBuffer + instantiate` when the response is served with the wrong MIME type, and our CDNs serve `application/wasm`, init fails with no recovery — the canvas stays blank.

This adds a final retry in `createWasmLoader`: after both streaming attempts fail, fetch the bytes ourselves and pass an `ArrayBuffer` to `init({ module_or_path })`, which routes through `WebAssembly.instantiate` and bypasses streaming entirely. Healthy environments still finish at the first streaming attempt — no perf regression.

Fixes #842
Refs #805 (resolves the WASM-init-failure component; the concurrent-mount blank-canvas symptom in that issue has a separate root cause)

## Package(s) affected

- [x] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [x] Tests have been added or updated
- [x] Changeset has been added (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAssembly loading reliability by adding a buffered fallback when streaming instantiation fails, preventing blank canvases on affected platforms (e.g., some iOS webviews). Retries now correctly attempt initialization after total failure.
* **Tests**
  * Strengthened test coverage to validate fallback ordering, buffered vs streaming behavior, retry semantics, and clearer failure logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->