### PR TITLE
ci: lock down pnpm install in non-test workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: lts/*
 
       - name: 📥 Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: 🏗 Build packages
         run: pnpm build:packages
@@ -70,7 +70,7 @@ jobs:
           node-version: lts/*
 
       - name: 📥 Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: 📦 Download build artifacts
         uses: actions/download-artifact@v8
@@ -103,7 +103,7 @@ jobs:
           node-version: lts/*
 
       - name: 📥 Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: 📦 Download build artifacts
         uses: actions/download-artifact@v8
@@ -217,7 +217,7 @@ jobs:
           node-version: lts/*
 
       - name: 📥 Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: 📏 Report bundle size
         uses: andresz1/size-limit-action@v1

--- a/.github/workflows/deploy-viewer.yml
+++ b/.github/workflows/deploy-viewer.yml
@@ -40,7 +40,7 @@ jobs:
           node-version: lts/*
 
       - name: 📥 Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: 🏗 Build
         run: pnpm build --filter='viewer...'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: 📥 Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: 🚀 Release to NPM
         id: changesets
@@ -145,7 +145,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: 📥 Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: 🏗 Build packages
         run: pnpm build:packages
@@ -192,7 +192,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: 📥 Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
 


### PR DESCRIPTION
## Description

Add `--frozen-lockfile --ignore-scripts` to all non-test `pnpm install` steps across `ci.yml`, `release.yml`, and `deploy-viewer.yml`. Test/validate installs left untouched.

## Package(s) affected

_None — CI-only change._

## Type of change

- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)