### PR TITLE
ci: deny-by-default workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:

--- a/.github/workflows/deploy-viewer.yml
+++ b/.github/workflows/deploy-viewer.yml
@@ -13,8 +13,7 @@ concurrency:
   group: deploy-viewer
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   deploy:

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   resolve-package:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       package_dir: ${{ steps.resolve.outputs.package_dir }}
       should_dispatch: ${{ steps.resolve.outputs.should_dispatch }}
@@ -43,6 +44,7 @@ jobs:
     needs: resolve-package
     if: needs.resolve-package.outputs.should_dispatch == 'true'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Dispatch to docs-content
         uses: peter-evans/repository-dispatch@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,7 @@ concurrency:
   group: release
   cancel-in-progress: false
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   validate:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,14 +3,14 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v9
         with:


### PR DESCRIPTION
## Description

Set `permissions: {}` at the top of every workflow and explicitly re-grant only what each job needs.

**Why deny-by-default at the top:** Without a top-level block, GitHub grants the workflow's `GITHUB_TOKEN` a broad read/write set by default (depending on repo settings). Switching to `{}` means any job that doesn't explicitly request a scope gets *zero* — so a compromised step (malicious dep, action hijack, injection) can't quietly call the GitHub API.

**Why explicit `permissions: {}` on notify-docs.yml jobs even though they'd inherit empty:** Inheritance is silent. If someone later widens the top-level for one job's needs, every other job silently inherits the new scope. Explicit `{}` per job means each job has to opt in to any permission upgrade — drift becomes loud.

**Why drop `contents: read` from stale.yml:** `actions/stale` only calls the issues/PRs APIs to label and comment — it never reads repo content (no checkout step). The previous `contents: read` was over-granting. The job-level block now only declares the two scopes it actually uses: `issues: write` and `pull-requests: write`.

## Package(s) affected

_None — CI-only change._

## Type of change

- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)