### PR TITLE
ci(release): isolate GPR token in ephemeral npmrc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,20 +150,18 @@ jobs:
       - name: 🏗 Build packages
         run: pnpm build:packages
 
-      - name: ⎔ Configure GPR registry for @lottiefiles scope
+      - name: 🚀 Publish to GitHub Packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          NPMRC=$(mktemp)
+          trap 'rm -f "$NPMRC"' EXIT
           {
             echo "@lottiefiles:registry=https://npm.pkg.github.com/"
-            echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}"
-          } >> .npmrc
-
-      - name: 🚀 Publish to GitHub Packages
-        run: pnpm changeset publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            echo '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}'
+          } > "$NPMRC"
+          NPM_CONFIG_USERCONFIG="$NPMRC" pnpm changeset publish
 
   jsr-release:
     name: JSR Release


### PR DESCRIPTION
## Description

Merge gpr-release's "configure" and "publish" steps; write the npm registry config to a `mktemp` file with a `trap ... EXIT` cleanup, and point pnpm at it via `NPM_CONFIG_USERCONFIG`. The token line uses a literal `${NODE_AUTH_TOKEN}` placeholder so npm expands it from env at publish time — the secret never lands on disk.

## Package(s) affected

_None — CI-only change._

## Type of change

- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)