### PR TITLE
ci(release): drop NPMJS_TOKEN from jsr-release install step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,8 +197,6 @@ jobs:
 
       - name: 📥 Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
 
       # related issue https://github.com/denoland/deno/issues/26152
       - name: ⎔ Setup .npmrc (NPM) in web package


### PR DESCRIPTION
## Description

Remove the `env.NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}` block from the `pnpm install` step in `jsr-release`. Installation pulls only public `@lottiefiles/*` deps and doesn't need a publish token — npm-release and gpr-release install fine without it. The token stays in the later `Setup .npmrc (NPM) in web package` step where the JSR publish actually needs it.

## Package(s) affected

_None — CI-only change._

## Type of change

- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)