### PR TITLE
ci: add harden-runner audit to secret-handling jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,11 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: 🛡 Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -203,6 +208,11 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: 🛡 Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/deploy-viewer.yml
+++ b/.github/workflows/deploy-viewer.yml
@@ -26,6 +26,11 @@ jobs:
       pages: write
 
     steps:
+      - name: 🛡 Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -46,6 +46,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
+      - name: 🛡 Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: Dispatch to docs-content
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,11 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: 🛡 Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -128,6 +133,11 @@ jobs:
       packages: write
 
     steps:
+      - name: 🛡 Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -175,6 +185,11 @@ jobs:
       id-token: write
 
     steps:
+      - name: 🛡 Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,11 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: 🛡 Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Add `step-security/harden-runner@a5ad31d…` (v2.19.1) as the first step in every job that references `secrets.*`. Mode: `egress-policy: audit` — log outbound destinations only, no blocking. Once the audit logs show a stable endpoint set we can flip to `block`.

Covers: `ci.yml` (test, bundle-size), `release.yml` (npm-release, gpr-release, jsr-release), `deploy-viewer.yml` (deploy), `notify-docs.yml` (notify-docs), `stale.yml` (stale).

## Package(s) affected

_None — CI-only change._

## Type of change

- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)