### PR TITLE
chore: declare engines on published packages

### DIFF
--- a/.changeset/enforce-engines.md
+++ b/.changeset/enforce-engines.md
@@ -1,0 +1,10 @@
+---
+"@lottiefiles/dotlottie-react": patch
+"@lottiefiles/dotlottie-solid": patch
+"@lottiefiles/dotlottie-svelte": patch
+"@lottiefiles/dotlottie-vue": patch
+"@lottiefiles/dotlottie-wc": patch
+"@lottiefiles/dotlottie-web": patch
+---
+
+Declare `engines: { node: ">=18.17.0", npm: ">=9.5.0" }` so downstream installs run on toolchains capable of verifying npm provenance attestations.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,6 +15,10 @@
     "Abdelrahman Ashraf <a.theashraf@gmail.com>"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=18.17.0",
+    "npm": ">=9.5.0"
+  },
   "main": "dist/index.js",
   "module": "dist/index.js",
   "browser": "dist/browser/index.js",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -13,6 +13,10 @@
   "author": "LottieFiles",
   "contributors": [],
   "license": "MIT",
+  "engines": {
+    "node": ">=18.17.0",
+    "npm": ">=9.5.0"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -31,6 +31,10 @@
     "dist"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=18.17.0",
+    "npm": ">=9.5.0"
+  },
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && npm run package",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -15,6 +15,10 @@
     "Abdelrahman Ashraf <a.theashraf@gmail.com>"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=18.17.0",
+    "npm": ">=9.5.0"
+  },
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wc/package.json
+++ b/packages/wc/package.json
@@ -15,6 +15,10 @@
     "Abdelrahman Ashraf <a.theashraf@gmail.com>"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=18.17.0",
+    "npm": ">=9.5.0"
+  },
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,6 +15,10 @@
     "Abdelrahman Ashraf <a.theashraf@gmail.com>"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=18.17.0",
+    "npm": ">=9.5.0"
+  },
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Description

Add `engines: { node: ">=18.17.0", npm: ">=9.5.0" }` to every published `@lottiefiles/*` package so downstream installs land on toolchains capable of verifying npm provenance attestations. Includes a `patch` changeset covering all 6 packages.

## Package(s) affected

- [x] `@lottiefiles/dotlottie-web` (core)
- [x] `@lottiefiles/dotlottie-react`
- [x] `@lottiefiles/dotlottie-vue`
- [x] `@lottiefiles/dotlottie-svelte`
- [x] `@lottiefiles/dotlottie-solid`
- [x] `@lottiefiles/dotlottie-wc`

## Type of change

- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [x] Changeset has been added (if applicable)