### PR TITLE
chore: pin pnpm trust policy to no-downgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
       "lefthook",
       "playwright",
       "svelte-preprocess"
-    ]
+    ],
+    "trustPolicy": "no-downgrade"
   },
   "packageManager": "pnpm@10.29.3"
 }


### PR DESCRIPTION
## Description

Adds `"trustPolicy": "no-downgrade"` to the root `pnpm` config block. The original audit item (`verifyAttestations: true`) is **not** a real pnpm setting — it's an npm-CLI-only flag and pnpm would silently ignore it. `trustPolicy: "no-downgrade"` is the closest real defense and arguably the more useful one for this codebase: pnpm refuses any install where a dependency's trust level (verified publisher / 2FA / trusted-publisher attestation) regressed compared to a prior release — the exact signature of a Shai-Hulud-style maintainer-account takeover.

The check runs during **resolution**, so it gates dep additions and bumps rather than every `--frozen-lockfile` CI install — which is where the protection is actually needed.

Verified locally with a full `pnpm install --force` over ~1626 packages: no trust-downgrade violations, parses cleanly. The `Property trustPolicy is not allowed` JSON-schema warning in editors is schema-lag — pnpm 10.x recognizes the option.

## Package(s) affected

- [ ] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

(None — root tooling config only.)

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)