### PR TITLE
chore: add SECURITY.md with private vulnerability reporting

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes land on the latest published release of each package in this repo:
+
+- `@lottiefiles/dotlottie-web`
+- `@lottiefiles/dotlottie-react`
+- `@lottiefiles/dotlottie-solid`
+- `@lottiefiles/dotlottie-svelte`
+- `@lottiefiles/dotlottie-vue`
+- `@lottiefiles/dotlottie-wc`
+
+All packages are currently pre-1.0 — older minors are not backported. Please upgrade to the latest version to receive fixes.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security reports.** Public disclosure before a fix is released puts every consumer at risk.
+
+Use GitHub's Private Vulnerability Reporting:
+
+1. Go to the repo's [Security tab](https://github.com/LottieFiles/dotlottie-web/security/advisories/new).
+2. Click **Report a vulnerability**.
+3. Fill in the form with reproduction steps, affected package(s), and the version range you've tested.
+
+Reports are visible only to repo maintainers.
+
+## What to expect
+
+- **Acknowledgement** — within 5 business days.
+- **Assessment + remediation plan** — within 30 days of acknowledgement.
+- **Coordinated disclosure** — a GitHub Security Advisory is published alongside or shortly after the patched release. Reporters are credited unless they request otherwise.
+
+## Scope
+
+**In scope:**
+
+- Any package published from this repository under `@lottiefiles/dotlottie-*`.
+- The build, release, and CI configuration in this repository that could compromise a published artifact.
+
+**Out of scope:**
+
+- Vulnerabilities in third-party dependencies — please report those to the upstream project first; we track them via Dependabot.
+- Bugs without a security impact — file a regular issue.
+- Findings from automated scanners without a working proof of concept.


### PR DESCRIPTION
## Description

Adds `.github/SECURITY.md` to document how to report vulnerabilities privately, pointing reporters at GitHub's Private Vulnerability Reporting (`/security/advisories/new`). PVR has been enabled on the repo (`PUT /repos/.../private-vulnerability-reporting`) so the link is live the moment this merges.

Closes the gap where there was no documented private channel — meaning a researcher's only obvious path was a public issue, which discloses the vuln to attackers before any fix exists.

## Package(s) affected

- [ ] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

(None directly — repo-level community health file.)

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)