### PR TITLE
ci(release): use temp .npmrc for JSR publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,18 +196,22 @@ jobs:
       - name: 📥 Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      # related issue https://github.com/denoland/deno/issues/26152
-      - name: ⎔ Setup .npmrc (NPM) in web package
-        run: |
-          echo "@lottiefiles:registry=https://registry.npmjs.org/" >> ./packages/web/.npmrc
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPMJS_TOKEN }}" >> ./packages/web/.npmrc
-
       - name: 🔄 Sync version to jsr.json
         run: |
           VERSION=$(jq -r '.version' ./packages/web/package.json)
           jq '.version = $newVersion' --arg newVersion "$VERSION" ./packages/web/jsr.json > temp.json
           mv temp.json ./packages/web/jsr.json
 
+      # related issue https://github.com/denoland/deno/issues/26152
       - name: 🚀 Release to JSR
-        run: npx jsr publish --allow-dirty
         working-directory: packages/web
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+        run: |
+          NPMRC=$(mktemp)
+          trap 'rm -f "$NPMRC"' EXIT
+          {
+            echo "@lottiefiles:registry=https://registry.npmjs.org/"
+            echo '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}'
+          } > "$NPMRC"
+          NPM_CONFIG_USERCONFIG="$NPMRC" npx jsr publish --allow-dirty


### PR DESCRIPTION
## Description

Match the pattern already used by `gpr-release`: write the `.npmrc` to a `mktemp` file, point npm/Deno at it via `NPM_CONFIG_USERCONFIG`, and pass the token through `env:` (literal `${NODE_AUTH_TOKEN}` in the file, npm substitutes at read time).

Keeps `NPMJS_TOKEN` out of any in-repo file and out of the run-script text.

## Package(s) affected

_None — CI-only change._

## Type of change

- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)