### PR TITLE
ci: install Playwright via pnpm exec instead of npx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
             playwright-${{ runner.os }}-
 
       - name: Install Playwright
-        run: npx playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: 🛡️ Test (with coverage)
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install Playwright
-        run: npx playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: 🛡️ Test (Browser)
         run: pnpm test


### PR DESCRIPTION
## Description

Swap `npx playwright install` for `pnpm exec playwright install` in the test (`ci.yml`) and validate (`release.yml`) jobs. `pnpm exec` runs the binary from `node_modules/.bin/`, so the Playwright CLI version follows `pnpm-lock.yaml`. `npx` could resolve to "latest" if the local binary is missing.

## Package(s) affected

- [ ] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)