### PR TITLE
docs: use shared cover SVG in all package READMEs

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -6,7 +6,7 @@
 ![NPM](https://img.shields.io/npm/l/@lottiefiles/dotlottie-react)
 
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/23125742/201124166-c2a0bc2a-018b-463b-b291-944fb767b5c2.png" />
+  <img src="https://lottie.host/43f43646-b018-4d72-a96b-02a929cd9727/gARxdIetbE.svg" alt="dotLottie Web" width="550" />
 </p>
 
 ## Contents

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,7 +1,7 @@
 # @lottiefiles/dotlottie-solid
 
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/23125742/201124166-c2a0bc2a-018b-463b-b291-944fb767b5c2.png" />
+  <img src="https://lottie.host/43f43646-b018-4d72-a96b-02a929cd9727/gARxdIetbE.svg" alt="dotLottie Web" width="550" />
 </p>
 
 ## Contents

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -6,7 +6,7 @@
 ![NPM](https://img.shields.io/npm/l/@lottiefiles/dotlottie-svelte)
 
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/23125742/201124166-c2a0bc2a-018b-463b-b291-944fb767b5c2.png" />
+  <img src="https://lottie.host/43f43646-b018-4d72-a96b-02a929cd9727/gARxdIetbE.svg" alt="dotLottie Web" width="550" />
 </p>
 
 ## Contents

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -6,7 +6,7 @@
 ![NPM](https://img.shields.io/npm/l/@lottiefiles/dotlottie-vue)
 
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/23125742/201124166-c2a0bc2a-018b-463b-b291-944fb767b5c2.png" />
+  <img src="https://lottie.host/43f43646-b018-4d72-a96b-02a929cd9727/gARxdIetbE.svg" alt="dotLottie Web" width="550" />
 </p>
 
 ## Contents

--- a/packages/wc/README.md
+++ b/packages/wc/README.md
@@ -6,7 +6,7 @@
 ![NPM](https://img.shields.io/npm/l/@lottiefiles/dotlottie-wc)
 
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/23125742/201124166-c2a0bc2a-018b-463b-b291-944fb767b5c2.png" />
+  <img src="https://lottie.host/43f43646-b018-4d72-a96b-02a929cd9727/gARxdIetbE.svg" alt="dotLottie Web" width="550" />
 </p>
 
 ## Contents

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -7,7 +7,7 @@
 ![NPM](https://img.shields.io/npm/l/@lottiefiles/dotlottie-web)
 
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/23125742/201124166-c2a0bc2a-018b-463b-b291-944fb767b5c2.png" alt="dotLottie Logo" />
+  <img src="https://lottie.host/43f43646-b018-4d72-a96b-02a929cd9727/gARxdIetbE.svg" alt="dotLottie Web" width="550" />
 </p>
 
 ## Table of Contents


### PR DESCRIPTION
## Description

Sync all package READMEs to the new cover SVG used in the root README (#876), replacing the old PNG and normalizing the `alt` text.

## Package(s) affected

- [x] `@lottiefiles/dotlottie-web` (core)
- [x] `@lottiefiles/dotlottie-react`
- [x] `@lottiefiles/dotlottie-vue`
- [x] `@lottiefiles/dotlottie-svelte`
- [x] `@lottiefiles/dotlottie-solid`
- [x] `@lottiefiles/dotlottie-wc`

## Type of change

- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally