### PR TITLE
fix: 🐛 test relating to stateMachineGetInputs

### DIFF
--- a/packages/web/tests/dotlottie.test.ts
+++ b/packages/web/tests/dotlottie.test.ts
@@ -2466,6 +2466,8 @@ describe.each([
       const definedInputs = inputs as string[];
 
       const predefinedInputs: string[] = [
+        '@elapsedTime',
+        'Numeric',
         'a_exited',
         'Boolean',
         'Step',


### PR DESCRIPTION
## Description
- Fixes a test that validates stateMachineGetInputs() which now includes built-in `@elapsedTime`
<!-- Summarize your changes. If this fixes an issue, include "Fixes #<issue>" below. -->

## Package(s) affected

- [ ] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [ ] Changes have been tested locally
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)
