### PR TITLE
ci: add restore-keys to Release Playwright cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - name: Install Playwright
         run: pnpm exec playwright install --with-deps chromium


### PR DESCRIPTION
## Description

The Release workflow's Playwright cache step had no `restore-keys`, so any change to `pnpm-lock.yaml` busts the exact cache key and forces a cold `playwright install`. That cold download currently hangs after reaching 100%, blocking the release. This adds the same `restore-keys` fallback CI already uses, so the existing browser cache is reused and the download is skipped.

## Package(s) affected

- N/A (CI only)

## Type of change

- [x] Chore (build, CI, docs, refactor)

## Checklist

- [ ] Changes have been tested locally (N/A — release workflow; mirrors the working `restore-keys` config in `ci.yml`)
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)
