### PR TITLE
fix: forward loopCount through framework wrappers (#901)

### DIFF
--- a/.changeset/loop-count-wrapper-forwarding.md
+++ b/.changeset/loop-count-wrapper-forwarding.md
@@ -1,0 +1,9 @@
+---
+"@lottiefiles/dotlottie-react": patch
+"@lottiefiles/dotlottie-vue": patch
+"@lottiefiles/dotlottie-svelte": patch
+"@lottiefiles/dotlottie-solid": patch
+"@lottiefiles/dotlottie-wc": patch
+---
+
+Forward the `loopCount` option through the framework wrappers. Previously the React, Vue, Svelte, Solid, and Web Component wrappers never passed `loopCount` to the underlying `DotLottie` instance, so the core fell back to its default of `0` (infinite) and the animation always looped forever regardless of the configured value. The wrappers now forward `loopCount` on init, on `load()` when `src`/`data` change, and reactively when the prop changes.

--- a/packages/react/src/base-dotlottie-react.tsx
+++ b/packages/react/src/base-dotlottie-react.tsx
@@ -55,6 +55,7 @@ export const BaseDotLottieReact = <T extends DotLottie | DotLottieWorker>({
   dotLottieRefCallback,
   layout,
   loop,
+  loopCount,
   mode,
   playOnHover,
   renderConfig,
@@ -82,6 +83,7 @@ export const BaseDotLottieReact = <T extends DotLottie | DotLottieWorker>({
     speed,
     mode,
     loop,
+    loopCount,
     useFrameInterpolation,
     segment,
     backgroundColor,
@@ -152,6 +154,10 @@ export const BaseDotLottieReact = <T extends DotLottie | DotLottieWorker>({
   useEffect(() => {
     dotLottieRef.current?.setLoop(loop ?? false);
   }, [loop]);
+
+  useEffect(() => {
+    dotLottieRef.current?.setLoopCount(loopCount ?? 0);
+  }, [loopCount]);
 
   useEffect(() => {
     dotLottieRef.current?.setUseFrameInterpolation(useFrameInterpolation ?? true);

--- a/packages/react/tests/dotlottie-react.spec.tsx
+++ b/packages/react/tests/dotlottie-react.spec.tsx
@@ -120,6 +120,45 @@ describe.each([
     });
   });
 
+  test('calls dotLottie.setLoopCount when loopCount prop changes', async () => {
+    const onLoad = vi.fn();
+    const dotLottieRefCallback = vi.fn();
+
+    const { rerender } = await render(
+      <Component src={dotLottieSrc} autoplay loop dotLottieRefCallback={dotLottieRefCallback} />,
+    );
+
+    await vi.waitFor(() => {
+      expect(dotLottieRefCallback).toHaveBeenCalledTimes(1);
+    });
+
+    const dotLottie = dotLottieRefCallback.mock.calls[0]?.[0];
+
+    dotLottie?.addEventListener('load', onLoad);
+
+    await vi.waitFor(() => {
+      expect(onLoad).toHaveBeenCalledTimes(1);
+    });
+
+    const setLoopCount = vi.spyOn(dotLottie, 'setLoopCount');
+
+    rerender(<Component src={dotLottieSrc} autoplay loop loopCount={2} dotLottieRefCallback={dotLottieRefCallback} />);
+
+    await vi.waitFor(() => {
+      expect(setLoopCount).toHaveBeenCalledTimes(1);
+    });
+
+    expect(setLoopCount).toHaveBeenCalledWith(2);
+
+    rerender(<Component src={dotLottieSrc} autoplay loop dotLottieRefCallback={dotLottieRefCallback} />);
+
+    await vi.waitFor(() => {
+      expect(setLoopCount).toHaveBeenCalledTimes(2);
+    });
+
+    expect(setLoopCount).toHaveBeenCalledWith(0);
+  });
+
   test('calls dotLottie.setSpeed when speed prop changes', async () => {
     const onLoad = vi.fn();
     const dotLottieRefCallback = vi.fn();

--- a/packages/solid/src/dotlottie.tsx
+++ b/packages/solid/src/dotlottie.tsx
@@ -17,6 +17,7 @@ export const DotLottieSolid = (props: DotLottieSolidProps): JSX.Element => {
     'data',
     'mode',
     'loop',
+    'loopCount',
     'speed',
     'marker',
     'segment',

--- a/packages/solid/src/use-dotlottie.tsx
+++ b/packages/solid/src/use-dotlottie.tsx
@@ -136,6 +136,16 @@ export const useDotLottie = (config: DotLottieConfig): UseDotLottieReturn => {
       dotLottieInstance.setLoop(config.loop);
     }
   });
+  // loopCount
+  createEffect(() => {
+    const dotLottieInstance = dotLottie();
+
+    if (!dotLottieInstance) return;
+
+    if (typeof config.loopCount === 'number' && dotLottieInstance.isLoaded) {
+      dotLottieInstance.setLoopCount(config.loopCount);
+    }
+  });
   // useFrameInterpolation
   createEffect(() => {
     const dotLottieInstance = dotLottie();

--- a/packages/svelte/src/lib/Dotlottie.svelte
+++ b/packages/svelte/src/lib/Dotlottie.svelte
@@ -7,6 +7,7 @@
 		backgroundColor?: Config['backgroundColor'];
 		data?: Config['data'];
 		loop?: Config['loop'];
+		loopCount?: Config['loopCount'];
 		mode?: Config['mode'];
 		renderConfig?: Config['renderConfig'];
 		segment?: Config['segment'];
@@ -29,6 +30,7 @@
 		backgroundColor = undefined,
 		data = undefined,
 		loop = false,
+		loopCount = 0,
 		mode = 'forward',
 		renderConfig = undefined,
 		segment = undefined,
@@ -64,6 +66,7 @@
 				src,
 				autoplay: autoplay && !playOnHover,
 				loop,
+				loopCount,
 				speed,
 				data,
 				renderConfig,
@@ -163,6 +166,13 @@
 	});
 
 	$effect(() => {
+		const currentLoopCount = loopCount;
+		if (dotLottie && typeof currentLoopCount === 'number') {
+			dotLottie.setLoopCount(currentLoopCount);
+		}
+	});
+
+	$effect(() => {
 		if (dotLottie) {
 			dotLottie.setBackgroundColor(backgroundColor || '');
 		}
@@ -189,6 +199,7 @@
 				...untrack(() => ({
 					autoplay,
 					loop,
+					loopCount,
 					speed,
 					data,
 					renderConfig,
@@ -221,6 +232,7 @@
 					src,
 					autoplay,
 					loop,
+					loopCount,
 					speed,
 					renderConfig,
 					segment,

--- a/packages/svelte/tests/dotlottie-svelte.spec.ts
+++ b/packages/svelte/tests/dotlottie-svelte.spec.ts
@@ -108,6 +108,44 @@ describe('DotLottieSvelte', () => {
     });
   });
 
+  test('calls dotLottie.setLoopCount when loopCount prop changes', async () => {
+    const onLoad = vi.fn();
+    const dotLottieRefCallback = vi.fn();
+
+    const { rerender } = render(DotLottieSvelte, {
+      src: dotLottieSrc,
+      autoplay: true,
+      loop: true,
+      dotLottieRefCallback,
+    });
+
+    await vi.waitFor(() => {
+      expect(dotLottieRefCallback).toHaveBeenCalledTimes(1);
+    });
+
+    const dotLottie = dotLottieRefCallback.mock.calls[0][0];
+
+    dotLottie.addEventListener('load', onLoad);
+
+    await vi.waitFor(() => {
+      expect(onLoad).toHaveBeenCalledTimes(1);
+    });
+
+    const setLoopCount = vi.spyOn(dotLottie, 'setLoopCount');
+
+    rerender({ src: dotLottieSrc, autoplay: true, loop: true, loopCount: 2, dotLottieRefCallback });
+
+    await vi.waitFor(() => {
+      expect(setLoopCount).toHaveBeenCalledWith(2);
+    });
+
+    rerender({ src: dotLottieSrc, autoplay: true, loop: true, loopCount: 0, dotLottieRefCallback });
+
+    await vi.waitFor(() => {
+      expect(setLoopCount).toHaveBeenCalledWith(0);
+    });
+  });
+
   test('calls dotLottie.setSpeed when speed prop changes', async () => {
     const onLoad = vi.fn();
     const dotLottieRefCallback = vi.fn();

--- a/packages/vue/src/dotlottie.ts
+++ b/packages/vue/src/dotlottie.ts
@@ -32,6 +32,7 @@ export const DotLottieVue = defineComponent({
     backgroundColor: { type: String as PropType<DotLottieVueProps['backgroundColor']>, required: false },
     data: { type: [String, ArrayBuffer] as PropType<DotLottieVueProps['data']>, required: false },
     loop: { type: Boolean as PropType<DotLottieVueProps['loop']>, required: false },
+    loopCount: { type: Number as PropType<DotLottieVueProps['loopCount']>, required: false },
     mode: { type: String as PropType<DotLottieVueProps['mode']>, required: false },
     renderConfig: { type: Object as PropType<DotLottieVueProps['renderConfig']>, required: false },
     segment: {
@@ -58,6 +59,7 @@ export const DotLottieVue = defineComponent({
       data,
       layout,
       loop,
+      loopCount,
       marker,
       mode,
       playOnHover,
@@ -95,6 +97,7 @@ export const DotLottieVue = defineComponent({
         data: data?.value,
         layout: layout?.value,
         loop: loop?.value,
+        loopCount: loopCount?.value,
         marker: marker?.value,
         mode: mode?.value,
         autoplay: shouldAutoplay.value,
@@ -132,6 +135,14 @@ export const DotLottieVue = defineComponent({
       (newVal) => {
         if (dotLottie && typeof newVal !== 'undefined') {
           dotLottie.setLoop(newVal);
+        }
+      },
+    );
+    watch(
+      () => loopCount?.value,
+      (newVal) => {
+        if (dotLottie && typeof newVal !== 'undefined') {
+          dotLottie.setLoopCount(newVal);
         }
       },
     );

--- a/packages/wc/__tests__/dotlottie-wc.spec.ts
+++ b/packages/wc/__tests__/dotlottie-wc.spec.ts
@@ -237,6 +237,28 @@ describe.each([
     });
   });
 
+  test('calls dotLottie.setLoopCount when loopcount attribute changes', async () => {
+    const { element, rerender } = render(elementName, { src, loop: 'true' });
+
+    const dotLottie = element.dotLottie as DotLottie | DotLottieWorker;
+
+    await vi.waitFor(() => {
+      expect(dotLottie.isLoaded).toBe(true);
+    });
+
+    const setLoopCount = vi.spyOn(dotLottie, 'setLoopCount');
+
+    rerender({ src, loop: 'true', loopcount: '2' });
+
+    expect(setLoopCount).toHaveBeenCalledTimes(1);
+    expect(setLoopCount).toHaveBeenCalledWith(2);
+
+    rerender({ src, loop: 'true' });
+
+    expect(setLoopCount).toHaveBeenCalledTimes(2);
+    expect(setLoopCount).toHaveBeenCalledWith(0);
+  });
+
   test('useframeinterpolation="false" attribute on initial render disables interpolation', async () => {
     const { element } = render(elementName, { src, useframeinterpolation: 'false' });
 

--- a/packages/wc/src/base-dotlottie-wc.ts
+++ b/packages/wc/src/base-dotlottie-wc.ts
@@ -17,6 +17,9 @@ export abstract class BaseDotLottieWC<T extends DotLottie | DotLottieWorker> ext
   @property({ type: Boolean })
   public loop: Config['loop'];
 
+  @property({ type: Number })
+  public loopCount: Config['loopCount'];
+
   @property({ type: Boolean })
   public autoplay: Config['autoplay'];
 
@@ -83,6 +86,7 @@ export abstract class BaseDotLottieWC<T extends DotLottie | DotLottieWorker> ext
       src: this.src,
       data: this.data,
       loop: this.loop,
+      loopCount: this.loopCount,
       autoplay: this.autoplay,
       speed: this.speed,
       segment: this.segment,
@@ -152,6 +156,10 @@ export abstract class BaseDotLottieWC<T extends DotLottie | DotLottieWorker> ext
       this.dotLottie.setLoop(Boolean(value));
     }
 
+    if (name === 'loopcount') {
+      this.dotLottie.setLoopCount(value ? Number(value) : 0);
+    }
+
     if (name === 'useframeinterpolation') {
       this.dotLottie.setUseFrameInterpolation(typeof value === 'string' ? JSON.parse(value) : true);
     }
@@ -181,6 +189,7 @@ export abstract class BaseDotLottieWC<T extends DotLottie | DotLottieWorker> ext
         src: value,
         data: this.data,
         loop: this.loop,
+        loopCount: this.loopCount,
         autoplay: this.autoplay,
         speed: this.speed,
         segment: this.segment,
@@ -200,6 +209,7 @@ export abstract class BaseDotLottieWC<T extends DotLottie | DotLottieWorker> ext
         src: this.src,
         data: value,
         loop: this.loop,
+        loopCount: this.loopCount,
         autoplay: this.autoplay,
         speed: this.speed,
         segment: this.segment,


### PR DESCRIPTION
## Description

The React, Vue, Svelte, Solid, and WC wrappers never passed `loopCount` to the core `DotLottie`, so it always fell back to `0` (infinite). Now forwarded on init, on `load()`, and reactively. Fixes #901.

## Package(s) affected

- [x] `@lottiefiles/dotlottie-react`
- [x] `@lottiefiles/dotlottie-vue`
- [x] `@lottiefiles/dotlottie-svelte`
- [x] `@lottiefiles/dotlottie-solid`
- [x] `@lottiefiles/dotlottie-wc`

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Changes have been tested locally (React/Svelte/WC suites green; Vue/Solid have no test harness)
- [x] Tests have been added or updated (React, Svelte, WC)
- [x] Changeset has been added