### PR TITLE
ci: install chromium-headless-shell for browser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
             playwright-${{ runner.os }}-
 
       - name: Install Playwright
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium chromium-headless-shell
 
       - name: 🛡️ Test (with coverage)
         env:


### PR DESCRIPTION
## Description

The `Test` job installs Playwright with `pnpm exec playwright install --with-deps chromium`, but the tests run via `pnpm vitest run --browser.headless`, which needs the separate **`chrome-headless-shell`** binary. Modern Playwright no longer ships the headless shell as part of the full `chromium` download, so it was never being installed.

CI only stayed green because the `restore-keys: playwright-${{ runner.os }}-` fallback happened to restore a **stale cache** that still contained an old headless-shell build. Any PR that invalidated that cache — notably Dependabot bumps to vitest/Playwright — failed deterministically with:

```
browserType.launch: Executable doesn't exist at
.../chromium_headless_shell-*/chrome-headless-shell-linux64/chrome-headless-shell
```

Re-running the job never helped, because the same broken cache restored every time.

This adds `chromium-headless-shell` to the install step so the required binary is always present regardless of cache state. This unblocks the stalled Dependabot backlog (several PRs are currently red solely because of this).

## Package(s) affected

_None — CI only._

## Type of change

- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally _(CI-only change; verified via the failing Dependabot runs showing the missing `chrome-headless-shell` binary)_
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)