### PR TITLE
ci: make Playwright browser cache trustworthy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,9 +162,11 @@ jobs:
         uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
+          # Bump the `v2` prefix to bust caches poisoned by an earlier install
+          # command (e.g. one that fetched chromium but not chromium-headless-shell).
+          # No `restore-keys`: a partial/stale cache makes `playwright install`
+          # skip the download it needs, so a key miss must be a clean miss.
+          key: playwright-v2-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install Playwright
         run: pnpm exec playwright install --with-deps chromium chromium-headless-shell


### PR DESCRIPTION
## Description

Follow-up to #904. Adding `chromium-headless-shell` to the install command was **necessary but not sufficient**: the `Test` job still failed because `playwright install` **skipped the browser download entirely** when a stale or partial `~/.cache/ms-playwright` was restored — leaving the required `chrome-headless-shell` build absent at test time (`browserType.launch: Executable doesn't exist at .../chromium_headless_shell-*/...`).

Two cache problems:

- **`restore-keys: playwright-${{ runner.os }}-`** restored *any* older Playwright cache on a key miss. Playwright's "already installed" check is coarse (it trusts the presence of the browsers dir), so it then skipped fetching the correct build.
- A **previous failed run** (using the old `chromium`-only install command) **saved a poisoned cache** — no headless-shell — under the exact `pnpm-lock.yaml`-hash key. Every subsequent exact-key hit inherited the poison.

### Fix

- Bump the cache-key prefix to **`v2`** to abandon poisoned caches.
- **Remove `restore-keys`** so a key miss is a *clean* miss that triggers a real, correct `playwright install` download.

This is what actually unblocks the stalled Dependabot PRs (any PR that changes the lockfile currently fails deterministically on this).

## Package(s) affected

_None — CI only._

## Type of change

- [x] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally _(CI-only; validated against the failing Dependabot Test runs — install step skipped browser download due to restored cache)_
- [ ] Tests have been added or updated
- [ ] Changeset has been added (if applicable)