### PR TITLE
chore: bump root playwright to ^1.60.0 to match vitest browser provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@vitest/coverage-istanbul": "^4.0.18",
     "lefthook": "^2.1.0",
     "npm-check-updates": "19.3.2",
-    "playwright": "^1.52.0",
+    "playwright": "^1.60.0",
     "remark-cli": "11.0.0",
     "size-limit": "^11.1.6",
     "svelte-loader": "^3.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 19.3.2
         version: 19.3.2
       playwright:
-        specifier: ^1.52.0
-        version: 1.52.0
+        specifier: ^1.60.0
+        version: 1.60.0
       remark-cli:
         specifier: 11.0.0
         version: 11.0.0
@@ -5802,18 +5802,8 @@ packages:
     resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
     hasBin: true
 
-  playwright-core@1.52.0:
-    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.52.0:
-    resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -13103,15 +13093,7 @@ snapshots:
     dependencies:
       pngjs: 7.0.0
 
-  playwright-core@1.52.0: {}
-
   playwright-core@1.60.0: {}
-
-  playwright@1.52.0:
-    dependencies:
-      playwright-core: 1.52.0
-    optionalDependencies:
-      fsevents: 2.3.2
 
   playwright@1.60.0:
     dependencies:


### PR DESCRIPTION
## Description

Fixes the long-standing `Test` job flakiness at its root (supersedes #904 / #905, which treated symptoms).