### PR TITLE
fix: export setWasmUrl from wc CDN bundles

### DIFF
--- a/.changeset/witty-donuts-shout.md
+++ b/.changeset/witty-donuts-shout.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-wc': patch
+---
+
+re-export `setWasmUrl` from the `dotlottie-wc` and `dotlottie-worker-wc` CDN bundles

--- a/packages/wc/README.md
+++ b/packages/wc/README.md
@@ -21,6 +21,7 @@
   * [Attributes](#attributes)
 * [RenderConfig](#renderconfig)
   * [Properties](#properties)
+  * [Custom WASM URL](#custom-wasm-url)
 * [Development](#development)
   * [Setup](#setup)
   * [Dev](#dev)
@@ -109,6 +110,28 @@ The `dotlottie-wc` exposes the following properties:
 | Property name | Type        | Description                                                                                                                                                         |
 | ------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `dotLottie`   | `DotLottie` | The dotLottie instance from [`DotLottie`](../web/README.md#documentation)  , allowing you to call methods and listen to events for more control over the animation. |
+
+### Custom WASM URL
+
+By default, the player's WebAssembly file is loaded from a CDN. If you need to serve it from your own host (e.g. environments where CDN access is restricted), use `setWasmUrl` before any animation loads:
+
+```js
+import { setWasmUrl } from '@lottiefiles/dotlottie-wc';
+
+setWasmUrl('/js/dotlottie/dotlottie-player.wasm');
+```
+
+The function is also exported from the CDN bundles, so it works when loading `dist/dotlottie-wc.js` or `dist/dotlottie-worker-wc.js` directly:
+
+```html
+<script type="module">
+  import { setWasmUrl } from 'https://unpkg.com/@lottiefiles/dotlottie-wc@latest/dist/dotlottie-wc.js';
+
+  setWasmUrl('/js/dotlottie/dotlottie-player.wasm');
+</script>
+```
+
+You can find the matching `dotlottie-player.wasm` for your installed version inside the `@lottiefiles/dotlottie-web` package (`dist/dotlottie-player.wasm`) or on a npm CDN, e.g. `https://unpkg.com/@lottiefiles/dotlottie-web@x.y.z/dist/dotlottie-player.wasm`.
 
 ## Development
 

--- a/packages/wc/__tests__/exports.spec.ts
+++ b/packages/wc/__tests__/exports.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+
+describe('entry module exports', () => {
+  test('index exports setWasmUrl', async () => {
+    const mod: Record<string, unknown> = await import('../src');
+
+    expect(typeof mod['setWasmUrl']).toBe('function');
+  });
+
+  test('dotlottie-wc entry exports setWasmUrl', async () => {
+    const mod: Record<string, unknown> = await import('../src/dotlottie-wc');
+
+    expect(typeof mod['setWasmUrl']).toBe('function');
+  });
+
+  test('dotlottie-worker-wc entry exports setWasmUrl', async () => {
+    const mod: Record<string, unknown> = await import('../src/dotlottie-worker-wc');
+
+    expect(typeof mod['setWasmUrl']).toBe('function');
+  });
+});

--- a/packages/wc/src/dotlottie-wc.ts
+++ b/packages/wc/src/dotlottie-wc.ts
@@ -5,6 +5,8 @@ import { customElement } from 'lit/decorators.js';
 
 import { BaseDotLottieWC } from './base-dotlottie-wc';
 
+export { setWasmUrl } from './set-wasm-url';
+
 @customElement('dotlottie-wc')
 export class DotLottieWC extends BaseDotLottieWC<DotLottie> {
   protected override _createDotLottieInstance(config: Config): DotLottie {

--- a/packages/wc/src/dotlottie-worker-wc.ts
+++ b/packages/wc/src/dotlottie-worker-wc.ts
@@ -5,6 +5,8 @@ import { customElement } from 'lit/decorators.js';
 
 import { BaseDotLottieWC } from './base-dotlottie-wc';
 
+export { setWasmUrl } from './set-wasm-url';
+
 @customElement('dotlottie-worker-wc')
 export class DotLottieWorkerWC extends BaseDotLottieWC<DotLottieWorker> {
   protected override _createDotLottieInstance(config: Config & { workerId?: string }): DotLottieWorker {

--- a/packages/wc/src/index.ts
+++ b/packages/wc/src/index.ts
@@ -1,10 +1,3 @@
-import { DotLottie, DotLottieWorker } from '@lottiefiles/dotlottie-web';
-
 export * from './dotlottie-wc';
 export * from './dotlottie-worker-wc';
-
-export const setWasmUrl = (url: string): void => {
-  // Consider refactoring setWasmUrl to a named export for improved tree-shaking efficiency
-  DotLottie.setWasmUrl(url);
-  DotLottieWorker.setWasmUrl(url);
-};
+export * from './set-wasm-url';

--- a/packages/wc/src/set-wasm-url.ts
+++ b/packages/wc/src/set-wasm-url.ts
@@ -1,0 +1,6 @@
+import { DotLottie, DotLottieWorker } from '@lottiefiles/dotlottie-web';
+
+export const setWasmUrl = (url: string): void => {
+  DotLottie.setWasmUrl(url);
+  DotLottieWorker.setWasmUrl(url);
+};


### PR DESCRIPTION
## Description

`setWasmUrl` disappeared from `dist/dotlottie-wc.js` after the build tooling change — it was only exported from `dist/index.js`, so anyone loading the CDN bundle directly (as the README suggests) couldn't set a self-hosted WASM path anymore. Moved it into a shared module and re-exported it from both component entries, plus documented it in the README.

Fixes #557

## Package(s) affected

- [ ] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [x] `@lottiefiles/dotlottie-wc`

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [x] Tests have been added or updated
- [x] Changeset has been added (if applicable)