### PR TITLE
fix: declare wasm max memory for Safari memory.grow bug

### DIFF
--- a/.changeset/wasm-max-memory.md
+++ b/.changeset/wasm-max-memory.md
@@ -1,0 +1,5 @@
+---
+"@lottiefiles/dotlottie-web": patch
+---
+
+Declare a 2GB WASM memory maximum so Safari grows memory in place, fixing iOS 15 freezes.

--- a/packages/web/Makefile
+++ b/packages/web/Makefile
@@ -27,6 +27,7 @@ WEB_SRC_WEBGL  := src/webgl
 WEB_SRC_WEBGPU := src/webgpu
 
 WASM_TARGET := wasm32-unknown-unknown
+WASM_MAX_MEMORY ?= 2147483648
 WASM_MANIFEST := $(DOTLOTTIE_RS_CRATE)/Cargo.toml
 WASM_ARTIFACT := $(DOTLOTTIE_RS_CRATE)/target/$(WASM_TARGET)/release/dotlottie_rs.wasm
 WASM_LOCKFILE := $(DOTLOTTIE_RS_CRATE)/Cargo.lock
@@ -104,7 +105,7 @@ setup:
 # $(4) = web src directory (e.g. $(WEB_SRC_CORE))
 define wasm_build
 	@mkdir -p $(3)
-	CC=$(WASM_CC) CXX=$(WASM_CXX) RUSTFLAGS="$(2)" \
+	CC=$(WASM_CC) CXX=$(WASM_CXX) RUSTFLAGS="$(2) -C link-arg=--max-memory=$(WASM_MAX_MEMORY)" \
 		cargo rustc \
 			--manifest-path $(WASM_MANIFEST) \
 			--crate-type cdylib \


### PR DESCRIPTION
## Description

Our wasm-bindgen builds declare no maximum memory, so WebKit reallocates the whole buffer on every `memory.grow` instead of growing in place — a path with known bugs on iOS 15 that match the freezes reported in #819. The old emscripten builds always declared a 2GB max and never hit this.

This passes `--max-memory=2GB` to wasm-ld across all three backends (software, webgl, webgpu). A declared max only reserves address space, so runtime memory usage is unchanged. Binaries pick this up on the next wasm rebuild.

## Package(s) affected

- [x] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [x] Changeset has been added (if applicable)
