### PR TITLE
fix: make DotLottieWorker tree-shakable and shrink inline worker encoding

### DIFF
--- a/.changeset/faster-first-frame.md
+++ b/.changeset/faster-first-frame.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+faster first frame: the animation now downloads in parallel with the WASM module instead of after it, the load path renders once instead of twice, and animation JSON is no longer parsed twice

--- a/.changeset/lazy-worker-treeshake.md
+++ b/.changeset/lazy-worker-treeshake.md
@@ -2,4 +2,4 @@
 '@lottiefiles/dotlottie-web': patch
 ---
 
-fixed bundlers not being able to tree-shake `DotLottieWorker`: apps that only use `DotLottie` no longer ship the inlined worker code (~37.6 KB → ~11.9 KB gzip)
+fixed bundlers not being able to tree-shake `DotLottieWorker`: apps that only use `DotLottie` no longer ship the inlined worker code (\~37.6 KB → \~11.9 KB gzip)

--- a/.changeset/lazy-worker-treeshake.md
+++ b/.changeset/lazy-worker-treeshake.md
@@ -4,4 +4,4 @@
 
 fix: make DotLottieWorker tree-shakable and shrink the inlined worker encoding
 
-Static field initializers and module-scope wasm loader calls were emitted as top-level side effects, forcing every consumer to bundle the inlined worker (341 KB raw / 37.6 KB gzip) even when only `DotLottie` was imported. They are now lazy, and the worker is embedded as a string literal instead of a decimal byte array. Importing only `DotLottie` now bundles ~55 KB raw / 11.9 KB gzip.
+Static field initializers and module-scope wasm loader calls were emitted as top-level side effects, forcing every consumer to bundle the inlined worker (341 KB raw / 37.6 KB gzip) even when only `DotLottie` was imported. They are now lazy, and the worker is embedded as a string literal instead of a decimal byte array. Importing only `DotLottie` now bundles \~55 KB raw / 11.9 KB gzip.

--- a/.changeset/lazy-worker-treeshake.md
+++ b/.changeset/lazy-worker-treeshake.md
@@ -1,0 +1,7 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+fix: make DotLottieWorker tree-shakable and shrink the inlined worker encoding
+
+Static field initializers and module-scope wasm loader calls were emitted as top-level side effects, forcing every consumer to bundle the inlined worker (341 KB raw / 37.6 KB gzip) even when only `DotLottie` was imported. They are now lazy, and the worker is embedded as a string literal instead of a decimal byte array. Importing only `DotLottie` now bundles ~55 KB raw / 11.9 KB gzip.

--- a/.changeset/lazy-worker-treeshake.md
+++ b/.changeset/lazy-worker-treeshake.md
@@ -2,6 +2,4 @@
 '@lottiefiles/dotlottie-web': patch
 ---
 
-fix: make DotLottieWorker tree-shakable and shrink the inlined worker encoding
-
-Static field initializers and module-scope wasm loader calls were emitted as top-level side effects, forcing every consumer to bundle the inlined worker (341 KB raw / 37.6 KB gzip) even when only `DotLottie` was imported. They are now lazy, and the worker is embedded as a string literal instead of a decimal byte array. Importing only `DotLottie` now bundles \~55 KB raw / 11.9 KB gzip.
+fixed bundlers not being able to tree-shake `DotLottieWorker`: apps that only use `DotLottie` no longer ship the inlined worker code (~37.6 KB → ~11.9 KB gzip)

--- a/.changeset/wasm-preload.md
+++ b/.changeset/wasm-preload.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': minor
+---
+
+added `DotLottie.preload()` to start the WASM download before the first player is constructed

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -15,6 +15,7 @@
 * [Introduction](#introduction)
   * [What is dotLottie?](#what-is-dotlottie)
 * [Documentation](#documentation)
+* [Faster First Frame](#faster-first-frame)
 * [Supported Platforms](#supported-platforms)
   * [Browser Requirements](#browser-requirements)
 * [Live Examples](#live-examples)
@@ -34,6 +35,31 @@ dotLottie is an open-source file format that bundles one or more Lottie animatio
 ## Documentation
 
 To get started with `@lottiefiles/dotlottie-web`, follow the [documentation here](https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-web/).
+
+## Faster First Frame
+
+The player's WASM engine (\~500 KB compressed) is fetched from a CDN when the first player is constructed. To take that download off your first animation's critical path:
+
+```js
+import { DotLottie } from '@lottiefiles/dotlottie-web';
+
+// At app or route load, before any player is constructed:
+DotLottie.preload();
+```
+
+Or let the browser start the download even earlier (`crossorigin` is required — without it the preloaded response can't be reused and the file downloads twice):
+
+```html
+<link rel="preconnect" href="https://cdn.jsdelivr.net" />
+<link
+  rel="preload"
+  as="fetch"
+  crossorigin
+  href="https://cdn.jsdelivr.net/npm/@lottiefiles/dotlottie-web@0.77.1/dist/dotlottie-player.wasm"
+/>
+```
+
+The version in the URL must match your installed package version — the player fetches a version-pinned URL, and a mismatch means the preload can't be reused. If you use `setWasmUrl()`, call it before `preload()` and point the preload tag at the same URL.
 
 ## Supported Platforms
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -71,7 +71,7 @@
     "thorvg"
   ],
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && node scripts/verify-dist.mjs",
     "dev": "tsdown --watch",
     "lint": "biome check --write .",
     "stats:ts": "tsc -p tsconfig.build.json --extendedDiagnostics",

--- a/packages/web/rolldown-plugins/plugin-inline-worker.ts
+++ b/packages/web/rolldown-plugins/plugin-inline-worker.ts
@@ -55,13 +55,12 @@ export function pluginInlineWorker(pkg: { name: string; version: string }): Roll
 
           const { text } = outputFiles[0]!;
 
-          // Encoding invariants — each was violated once and caused a consumer regression:
-          // 1. Embed the worker source as ONE string literal, never an element-per-byte
-          //    Uint8Array literal: bundlers allocate an AST node per element, which blew up
-          //    consumer build times and bundle sizes (issue #344).
-          // 2. `new Worker()` must receive a variable, never a string/data-URL literal:
-          //    Parcel statically analyzes literal Worker() arguments and fails the build
-          //    (issue #333).
+          // Two constraints on the emitted code:
+          // - Keep the worker source a single string literal. Encoding it as a
+          //   Uint8Array byte literal creates one AST node per byte, slowing consumer
+          //   builds and bloating bundles (#344).
+          // - Pass `new Worker()` a variable, not a string/data-URL literal. Parcel
+          //   statically analyzes literal Worker() arguments and fails the build (#333).
           return {
             code: `
               "use client";

--- a/packages/web/rolldown-plugins/plugin-inline-worker.ts
+++ b/packages/web/rolldown-plugins/plugin-inline-worker.ts
@@ -55,6 +55,13 @@ export function pluginInlineWorker(pkg: { name: string; version: string }): Roll
 
           const { text } = outputFiles[0]!;
 
+          // Encoding invariants — each was violated once and caused a consumer regression:
+          // 1. Embed the worker source as ONE string literal, never an element-per-byte
+          //    Uint8Array literal: bundlers allocate an AST node per element, which blew up
+          //    consumer build times and bundle sizes (issue #344).
+          // 2. `new Worker()` must receive a variable, never a string/data-URL literal:
+          //    Parcel statically analyzes literal Worker() arguments and fails the build
+          //    (issue #333).
           return {
             code: `
               "use client";

--- a/packages/web/rolldown-plugins/plugin-inline-worker.ts
+++ b/packages/web/rolldown-plugins/plugin-inline-worker.ts
@@ -53,7 +53,6 @@ export function pluginInlineWorker(pkg: { name: string; version: string }): Roll
             throw new Error('Too many files built for worker bundle.');
           }
 
-          // A string literal is ~3.7x smaller than a decimal byte-array encoding.
           const { text } = outputFiles[0]!;
 
           return {

--- a/packages/web/rolldown-plugins/plugin-inline-worker.ts
+++ b/packages/web/rolldown-plugins/plugin-inline-worker.ts
@@ -53,18 +53,19 @@ export function pluginInlineWorker(pkg: { name: string; version: string }): Roll
             throw new Error('Too many files built for worker bundle.');
           }
 
-          const { contents } = outputFiles[0]!;
-          const uint8Array = new Uint8Array(contents);
+          // A string literal is ~3.7x smaller than a decimal byte-array encoding.
+          const { text } = outputFiles[0]!;
 
           return {
             code: `
               "use client";
+              const workerCode = ${JSON.stringify(text)};
               class InlineWorker {
                 constructor() {
                   if (typeof Worker === 'undefined') {
                     throw new Error('Worker is not supported in this environment.');
                   }
-                  const blob = new Blob([new Uint8Array([${uint8Array.join(',')}])], { type: 'application/javascript' });
+                  const blob = new Blob([workerCode], { type: 'application/javascript' });
                   const url = URL.createObjectURL(blob);
                   const worker = new Worker(url);
                   URL.revokeObjectURL(url);

--- a/packages/web/scripts/verify-dist.mjs
+++ b/packages/web/scripts/verify-dist.mjs
@@ -1,0 +1,55 @@
+/**
+ * Post-build guard: fails the build if dist/index.js stops being tree-shakable.
+ *
+ * A `DotLottie`-only consumer bundle must not retain the inline worker. This broke
+ * once before: ES2020 down-levels static class fields into top-level side-effectful
+ * statements that no bundler can prove pure (issue #344). Statics on exported classes
+ * must use the module-level lazy-singleton pattern instead (see src/worker/dotlottie.ts).
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as esbuild from 'esbuild';
+
+const distDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../dist');
+
+// Thrown by the InlineWorker wrapper emitted by rolldown-plugins/plugin-inline-worker.ts.
+const WORKER_MARKER = 'Worker is not supported in this environment.';
+const MAX_DOTLOTTIE_ONLY_BYTES = 100_000; // 55 KB as of #925; worker would add ~95 KB.
+
+async function bundle(entry) {
+  const result = await esbuild.build({
+    stdin: { contents: entry, resolveDir: distDir, sourcefile: 'entry.js' },
+    bundle: true,
+    minify: true,
+    write: false,
+    format: 'esm',
+    logLevel: 'silent',
+  });
+
+  return result.outputFiles[0].text;
+}
+
+const fullBundle = await bundle(`export * from './index.js';`);
+
+if (!fullBundle.includes(WORKER_MARKER)) {
+  throw new Error(
+    'verify-dist: worker marker not found in a full-export bundle — the marker string moved and this guard is blind. Update WORKER_MARKER.',
+  );
+}
+
+const dotLottieOnly = await bundle(`export { DotLottie } from './index.js';`);
+
+if (dotLottieOnly.includes(WORKER_MARKER)) {
+  throw new Error(
+    'verify-dist: a DotLottie-only bundle retains the inline worker — dist/index.js has top-level side effects again (issue #344). Likely cause: a static class field on an exported class; use the lazy-singleton pattern.',
+  );
+}
+
+if (dotLottieOnly.length > MAX_DOTLOTTIE_ONLY_BYTES) {
+  throw new Error(
+    `verify-dist: DotLottie-only bundle is ${dotLottieOnly.length} bytes (limit ${MAX_DOTLOTTIE_ONLY_BYTES}). Raise the limit deliberately if this growth is intended.`,
+  );
+}
+
+console.log(`verify-dist: ok — DotLottie-only bundle is ${dotLottieOnly.length} bytes, worker tree-shaken.`);

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -114,7 +114,9 @@ const fitToString = (fit: string): Fit => {
 export class DotLottie {
   protected _canvas: HTMLCanvasElement | OffscreenCanvas | RenderSurface | null = null;
 
-  private _pendingLoad: { data?: Data; src?: string } | null = null;
+  private _pendingLoad: { data?: Data; dataPromise?: Promise<string | ArrayBuffer> | null; src?: string } | null = null;
+
+  private _srcFetchAbort: AbortController | null = null;
 
   protected _context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null = null;
 
@@ -187,6 +189,15 @@ export class DotLottie {
       freezeOnOffscreen: config.renderConfig?.freezeOnOffscreen ?? true,
     };
 
+    let srcPrefetch: Promise<string | ArrayBuffer> | null = null;
+
+    if (config.src && !config.data) {
+      this._srcFetchAbort = new AbortController();
+      srcPrefetch = this._fetchData(config.src, this._srcFetchAbort.signal);
+      // Errors surface via _loadFromSrc after 'ready'; this only avoids an unhandled rejection.
+      srcPrefetch.catch(() => {});
+    }
+
     this._initWasm()
       .then(() => {
         this._dotLottieCore = this._createCore();
@@ -227,9 +238,9 @@ export class DotLottie {
           }
         } else if (config.src) {
           if (this._canvas) {
-            this._loadFromSrc(config.src);
+            this._loadFromSrc(config.src, srcPrefetch);
           } else {
-            this._pendingLoad = { src: config.src };
+            this._pendingLoad = { src: config.src, dataPromise: srcPrefetch };
           }
         }
 
@@ -238,6 +249,7 @@ export class DotLottie {
         }
       })
       .catch((error) => {
+        this._srcFetchAbort?.abort();
         console.error('[dotlottie-web] Initialization failed:', error);
         this._eventManager.dispatch({
           type: 'loadError',
@@ -320,6 +332,12 @@ export class DotLottie {
         default:
           break;
       }
+    }
+  }
+
+  private _discardPlayerEvents(): void {
+    while (this._dotLottieCore?.poll_event() != null) {
+      // Drop stale core events already reported with a more specific message.
     }
   }
 
@@ -445,8 +463,8 @@ export class DotLottie {
     this._eventManager.dispatch({ type: 'loadError', error: new Error(message) });
   }
 
-  private async _fetchData(src: string): Promise<string | ArrayBuffer> {
-    const response = await fetch(src);
+  private async _fetchData(src: string, signal: AbortSignal | null = null): Promise<string | ArrayBuffer> {
+    const response = await fetch(src, { signal });
 
     if (!response.ok) {
       throw new Error(`Failed to fetch animation data from URL: ${src}. ${response.status}: ${response.statusText}`);
@@ -471,22 +489,23 @@ export class DotLottie {
       return;
     }
 
-    const width = this._canvas.width;
-    const height = this._canvas.height;
-
-    this._setupTarget(width, height);
+    this._syncCanvasSize();
+    this._setupTarget(this._canvas.width, this._canvas.height);
 
     let loaded = false;
 
     if (typeof data === 'string') {
-      if (!isLottie(data)) {
+      loaded = this._dotLottieCore.load_animation(data);
+
+      // isLottie() is a full JSON.parse; run it only on failure to pick the specific error message.
+      if (!loaded && !isLottie(data)) {
+        this._discardPlayerEvents();
         this._dispatchError(
           'Invalid Lottie JSON string: The provided string does not conform to the Lottie JSON format.',
         );
 
         return;
       }
-      loaded = this._dotLottieCore.load_animation(data);
     } else if (data instanceof ArrayBuffer) {
       if (!isDotLottie(data)) {
         this._dispatchError(
@@ -520,10 +539,6 @@ export class DotLottie {
     if (loaded) {
       if (this._renderConfig.quality !== undefined) {
         this._dotLottieCore.set_quality(this._renderConfig.quality);
-      }
-
-      if (IS_BROWSER) {
-        this.resize();
       }
 
       // Drain any events produced by loading (Load/LoadError).
@@ -592,8 +607,8 @@ export class DotLottie {
     }
   }
 
-  private _loadFromSrc(src: string): void {
-    this._fetchData(src)
+  private _loadFromSrc(src: string, prefetched?: Promise<string | ArrayBuffer> | null): void {
+    (prefetched ?? this._fetchData(src))
       .then((data) => this._loadFromData(data))
       .catch((error) => this._dispatchError(`Failed to load animation data from URL: ${src}. ${error}`));
   }
@@ -1283,6 +1298,10 @@ export class DotLottie {
 
     this._cleanupCanvas();
 
+    this._srcFetchAbort?.abort();
+    this._srcFetchAbort = null;
+    this._pendingLoad = null;
+
     const core = this._dotLottieCore;
 
     this._dotLottieCore = null;
@@ -1336,19 +1355,23 @@ export class DotLottie {
    * Recalculates and updates canvas dimensions based on current size.
    * Call this when the canvas container size changes to maintain proper rendering. Usually handled by autoResize.
    */
+  private _syncCanvasSize(): void {
+    if (!(IS_BROWSER && this._canvas instanceof HTMLCanvasElement)) return;
+
+    const dpr = this._renderConfig.devicePixelRatio || window.devicePixelRatio || 1;
+
+    const { height: clientHeight, width: clientWidth } = this._canvas.getBoundingClientRect();
+
+    if (clientHeight !== 0 && clientWidth !== 0) {
+      this._canvas.width = clientWidth * dpr;
+      this._canvas.height = clientHeight * dpr;
+    }
+  }
+
   public resize(): void {
     if (!this._dotLottieCore || !this.isLoaded || !this._canvas) return;
 
-    if (IS_BROWSER && this._canvas instanceof HTMLCanvasElement) {
-      const dpr = this._renderConfig.devicePixelRatio || window.devicePixelRatio || 1;
-
-      const { height: clientHeight, width: clientWidth } = this._canvas.getBoundingClientRect();
-
-      if (clientHeight !== 0 && clientWidth !== 0) {
-        this._canvas.width = clientWidth * dpr;
-        this._canvas.height = clientHeight * dpr;
-      }
-    }
+    this._syncCanvasSize();
 
     const resized = this._setupTarget(this._canvas.width, this._canvas.height);
 
@@ -1383,7 +1406,7 @@ export class DotLottie {
       if (pending.data) {
         this._loadFromData(pending.data);
       } else if (pending.src) {
-        this._loadFromSrc(pending.src);
+        this._loadFromSrc(pending.src, pending.dataPromise);
       }
     }
   }
@@ -1507,6 +1530,7 @@ export class DotLottie {
   public loadAnimation(animationId: string): void {
     if (this._dotLottieCore === null || this._dotLottieCore.animation_id() === animationId || !this._canvas) return;
 
+    this._syncCanvasSize();
     this._setupTarget(this._canvas.width, this._canvas.height);
     const loaded = this._dotLottieCore.load_animation_from_id(animationId);
 
@@ -1514,7 +1538,6 @@ export class DotLottie {
       if (this._renderConfig.quality !== undefined) {
         this._dotLottieCore.set_quality(this._renderConfig.quality);
       }
-      this.resize();
       this._drainPlayerEvents();
 
       this._dotLottieCore.render();
@@ -1959,6 +1982,14 @@ export class DotLottie {
    */
   public static setWasmUrl(url: string): void {
     dotLottieWasmLoader().setWasmUrl(url);
+  }
+
+  /**
+   * Starts fetching and compiling the WASM module before any player is constructed.
+   * Call this at app or route load to take the WASM download off the first animation's critical path.
+   */
+  public static preload(): Promise<void> {
+    return dotLottieWasmLoader().load();
   }
 
   /**

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -40,7 +40,6 @@ import { createWasmLoader } from './wasm-loader';
 
 let dotLottieWasmLoaderSingleton: ReturnType<typeof createWasmLoader> | null = null;
 
-// Lazy: a module-scope call is a side effect that blocks consumer tree-shaking.
 function dotLottieWasmLoader(): ReturnType<typeof createWasmLoader> {
   dotLottieWasmLoaderSingleton ??= createWasmLoader(
     init,

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -38,11 +38,18 @@ import {
 } from './utils';
 import { createWasmLoader } from './wasm-loader';
 
-const dotLottieWasmLoader = createWasmLoader(
-  init,
-  `https://cdn.jsdelivr.net/npm/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/dotlottie-player.wasm`,
-  `https://unpkg.com/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/dotlottie-player.wasm`,
-);
+let dotLottieWasmLoaderSingleton: ReturnType<typeof createWasmLoader> | null = null;
+
+// Lazy: a module-scope call is a side effect that blocks consumer tree-shaking.
+function dotLottieWasmLoader(): ReturnType<typeof createWasmLoader> {
+  dotLottieWasmLoaderSingleton ??= createWasmLoader(
+    init,
+    `https://cdn.jsdelivr.net/npm/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/dotlottie-player.wasm`,
+    `https://unpkg.com/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/dotlottie-player.wasm`,
+  );
+
+  return dotLottieWasmLoaderSingleton;
+}
 
 // ── Mode conversion helpers ──────────────────────────────────────────────────
 
@@ -243,7 +250,7 @@ export class DotLottie {
   // ── Override hooks for subclasses ─────────────────────────────────────
 
   protected async _initWasm(): Promise<void> {
-    return dotLottieWasmLoader.load();
+    return dotLottieWasmLoader().load();
   }
 
   protected _createCore(): DotLottiePlayerWasm {
@@ -1952,7 +1959,7 @@ export class DotLottie {
    * @param url - URL pointing to the dotlottie WASM file
    */
   public static setWasmUrl(url: string): void {
-    dotLottieWasmLoader.setWasmUrl(url);
+    dotLottieWasmLoader().setWasmUrl(url);
   }
 
   /**
@@ -1964,7 +1971,7 @@ export class DotLottie {
    */
   public static async registerFont(fontName: string, fontSource: string | ArrayBuffer | Uint8Array): Promise<boolean> {
     try {
-      await dotLottieWasmLoader.load();
+      await dotLottieWasmLoader().load();
 
       let fontData: Uint8Array;
 

--- a/packages/web/src/webgl/dotlottie-webgl.ts
+++ b/packages/web/src/webgl/dotlottie-webgl.ts
@@ -9,7 +9,6 @@ import init, { DotLottiePlayerWasm } from './dotlottie-player';
 
 let webGLWasmLoaderSingleton: ReturnType<typeof createWasmLoader> | null = null;
 
-// Lazy: a module-scope call is a side effect that blocks consumer tree-shaking.
 function webGLWasmLoader(): ReturnType<typeof createWasmLoader> {
   webGLWasmLoaderSingleton ??= createWasmLoader(
     init,

--- a/packages/web/src/webgl/dotlottie-webgl.ts
+++ b/packages/web/src/webgl/dotlottie-webgl.ts
@@ -7,11 +7,18 @@ import { createWasmLoader } from '../wasm-loader';
 
 import init, { DotLottiePlayerWasm } from './dotlottie-player';
 
-const webGLWasmLoader = createWasmLoader(
-  init,
-  `https://cdn.jsdelivr.net/npm/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/webgl/dotlottie-player.wasm`,
-  `https://unpkg.com/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/webgl/dotlottie-player.wasm`,
-);
+let webGLWasmLoaderSingleton: ReturnType<typeof createWasmLoader> | null = null;
+
+// Lazy: a module-scope call is a side effect that blocks consumer tree-shaking.
+function webGLWasmLoader(): ReturnType<typeof createWasmLoader> {
+  webGLWasmLoaderSingleton ??= createWasmLoader(
+    init,
+    `https://cdn.jsdelivr.net/npm/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/webgl/dotlottie-player.wasm`,
+    `https://unpkg.com/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/webgl/dotlottie-player.wasm`,
+  );
+
+  return webGLWasmLoaderSingleton;
+}
 
 export class DotLottieWebGL extends DotLottie {
   // biome-ignore lint/complexity/noUselessConstructor: narrows canvas to HTMLCanvasElement (WebGLConfig vs Config)
@@ -20,7 +27,7 @@ export class DotLottieWebGL extends DotLottie {
   }
 
   protected override async _initWasm(): Promise<void> {
-    return webGLWasmLoader.load();
+    return webGLWasmLoader().load();
   }
 
   protected override _createCore(): CoreDotLottiePlayerWasm {
@@ -88,6 +95,6 @@ export class DotLottieWebGL extends DotLottie {
   }
 
   public static override setWasmUrl(url: string): void {
-    webGLWasmLoader.setWasmUrl(url);
+    webGLWasmLoader().setWasmUrl(url);
   }
 }

--- a/packages/web/src/webgl/dotlottie-webgl.ts
+++ b/packages/web/src/webgl/dotlottie-webgl.ts
@@ -96,4 +96,12 @@ export class DotLottieWebGL extends DotLottie {
   public static override setWasmUrl(url: string): void {
     webGLWasmLoader().setWasmUrl(url);
   }
+
+  /**
+   * Starts fetching and compiling the WASM module before any player is constructed.
+   * Call this at app or route load to take the WASM download off the first animation's critical path.
+   */
+  public static override preload(): Promise<void> {
+    return webGLWasmLoader().load();
+  }
 }

--- a/packages/web/src/webgpu/dotlottie-webgpu.ts
+++ b/packages/web/src/webgpu/dotlottie-webgpu.ts
@@ -7,11 +7,18 @@ import { createWasmLoader } from '../wasm-loader';
 
 import init, { DotLottiePlayerWasm } from './dotlottie-player';
 
-const webGPUWasmLoader = createWasmLoader(
-  init,
-  `https://cdn.jsdelivr.net/npm/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/webgpu/dotlottie-player.wasm`,
-  `https://unpkg.com/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/webgpu/dotlottie-player.wasm`,
-);
+let webGPUWasmLoaderSingleton: ReturnType<typeof createWasmLoader> | null = null;
+
+// Lazy: a module-scope call is a side effect that blocks consumer tree-shaking.
+function webGPUWasmLoader(): ReturnType<typeof createWasmLoader> {
+  webGPUWasmLoaderSingleton ??= createWasmLoader(
+    init,
+    `https://cdn.jsdelivr.net/npm/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/webgpu/dotlottie-player.wasm`,
+    `https://unpkg.com/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/webgpu/dotlottie-player.wasm`,
+  );
+
+  return webGPUWasmLoaderSingleton;
+}
 
 export class DotLottieWebGPU extends DotLottie {
   private _gpuDevice: GPUDevice | null = null;
@@ -28,7 +35,7 @@ export class DotLottieWebGPU extends DotLottie {
   }
 
   protected override async _initWasm(): Promise<void> {
-    await webGPUWasmLoader.load();
+    await webGPUWasmLoader().load();
 
     // Auto-initialize GPUDevice if user didn't provide one
     if (!this._userDevice) {
@@ -174,6 +181,6 @@ export class DotLottieWebGPU extends DotLottie {
   }
 
   public static override setWasmUrl(url: string): void {
-    webGPUWasmLoader.setWasmUrl(url);
+    webGPUWasmLoader().setWasmUrl(url);
   }
 }

--- a/packages/web/src/webgpu/dotlottie-webgpu.ts
+++ b/packages/web/src/webgpu/dotlottie-webgpu.ts
@@ -9,7 +9,6 @@ import init, { DotLottiePlayerWasm } from './dotlottie-player';
 
 let webGPUWasmLoaderSingleton: ReturnType<typeof createWasmLoader> | null = null;
 
-// Lazy: a module-scope call is a side effect that blocks consumer tree-shaking.
 function webGPUWasmLoader(): ReturnType<typeof createWasmLoader> {
   webGPUWasmLoaderSingleton ??= createWasmLoader(
     init,

--- a/packages/web/src/webgpu/dotlottie-webgpu.ts
+++ b/packages/web/src/webgpu/dotlottie-webgpu.ts
@@ -182,4 +182,12 @@ export class DotLottieWebGPU extends DotLottie {
   public static override setWasmUrl(url: string): void {
     webGPUWasmLoader().setWasmUrl(url);
   }
+
+  /**
+   * Starts fetching and compiling the WASM module before any player is constructed.
+   * Call this at app or route load to take the WASM download off the first animation's critical path.
+   */
+  public static override preload(): Promise<void> {
+    return webGPUWasmLoader().load();
+  }
 }

--- a/packages/web/src/worker/dotlottie.ts
+++ b/packages/web/src/worker/dotlottie.ts
@@ -70,14 +70,24 @@ export interface DotLottieInstanceState {
   useFrameInterpolation: boolean;
 }
 
+// Lazy, not a static field: ES2020 down-levels static fields to top-level side
+// effects, which blocks consumers from tree-shaking the inlined worker away.
+let workerManagerSingleton: WorkerManager | null = null;
+
+function workerManager(): WorkerManager {
+  workerManagerSingleton ??= new WorkerManager();
+
+  return workerManagerSingleton;
+}
+
+let workerWasmUrl = '';
+
 /**
  * Worker-based DotLottie player that offloads animation processing to a Web Worker thread.
  * Use this for better performance when rendering multiple animations or to keep the main thread responsive.
  * All methods are async (return Promises) due to worker communication. Requires HTMLCanvasElement or OffscreenCanvas.
  */
 export class DotLottieWorker {
-  private static readonly _workerManager = new WorkerManager();
-
   private readonly _eventManager = new EventManager();
 
   private readonly _id: string;
@@ -114,8 +124,6 @@ export class DotLottieWorker {
     isReady: false,
     manifest: null,
   };
-
-  private static _wasmUrl: string = '';
 
   private _created: boolean = false;
 
@@ -156,12 +164,12 @@ export class DotLottieWorker {
     const workerId = config.workerId || 'defaultWorker';
 
     // creates or gets the worker
-    this._worker = DotLottieWorker._workerManager.getWorker(workerId);
+    this._worker = workerManager().getWorker(workerId);
 
-    DotLottieWorker._workerManager.assignAnimationToWorker(this._id, workerId);
+    workerManager().assignAnimationToWorker(this._id, workerId);
 
-    if (DotLottieWorker._wasmUrl) {
-      this._sendMessage('setWasmUrl', { url: DotLottieWorker._wasmUrl });
+    if (workerWasmUrl) {
+      this._sendMessage('setWasmUrl', { url: workerWasmUrl });
     }
 
     const fullConfig = {
@@ -182,7 +190,7 @@ export class DotLottieWorker {
       this._pendingConfig = null;
     }
 
-    DotLottieWorker._workerManager.registerEventHandler(
+    workerManager().registerEventHandler(
       this._id,
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       this._handleWorkerEvent.bind(this),
@@ -768,8 +776,8 @@ export class DotLottieWorker {
 
     this._cleanupStateMachineListeners();
 
-    DotLottieWorker._workerManager.unregisterEventHandler(this._id);
-    DotLottieWorker._workerManager.unassignAnimationFromWorker(this._id);
+    workerManager().unregisterEventHandler(this._id);
+    workerManager().unassignAnimationFromWorker(this._id);
     this._eventManager.removeAllEventListeners();
 
     if (IS_BROWSER && this._canvas instanceof HTMLCanvasElement) {
@@ -984,8 +992,8 @@ export class DotLottieWorker {
     };
 
     return new Promise((resolve, reject) => {
-      DotLottieWorker._workerManager.registerRpcReplyHandler(rpcRequest.id, (event: MessageEvent) => {
-        DotLottieWorker._workerManager.unregisterRpcReplyHandler(rpcRequest.id);
+      workerManager().registerRpcReplyHandler(rpcRequest.id, (event: MessageEvent) => {
+        workerManager().unregisterRpcReplyHandler(rpcRequest.id);
 
         const rpcResponse: RpcResponse<T> = event.data;
 
@@ -1009,7 +1017,7 @@ export class DotLottieWorker {
   }
 
   public static setWasmUrl(url: string): void {
-    DotLottieWorker._wasmUrl = url;
+    workerWasmUrl = url;
   }
 
   /**
@@ -1024,7 +1032,7 @@ export class DotLottieWorker {
     try {
       const id = generateUniqueId();
 
-      DotLottieWorker._workerManager.broadcastMessage({
+      workerManager().broadcastMessage({
         id,
         method: 'registerFont',
         params: {

--- a/packages/web/src/worker/dotlottie.ts
+++ b/packages/web/src/worker/dotlottie.ts
@@ -70,8 +70,7 @@ export interface DotLottieInstanceState {
   useFrameInterpolation: boolean;
 }
 
-// Lazy, not a static field: ES2020 down-levels static fields to top-level side
-// effects, which blocks consumers from tree-shaking the inlined worker away.
+// Not static fields: ES2020 down-levels those to top-level side effects, breaking tree-shaking.
 let workerManagerSingleton: WorkerManager | null = null;
 
 function workerManager(): WorkerManager {

--- a/packages/web/tests/dotlottie.test.ts
+++ b/packages/web/tests/dotlottie.test.ts
@@ -801,6 +801,21 @@ describe.each([
   });
 
   describe('load', () => {
+    // preload() exists on the main-thread player only
+    (isWorker ? test.skip : test)('preload() warms the wasm module before construction', async () => {
+      await expect(DotLottieClass.preload()).resolves.toBeUndefined();
+
+      const onReady = vi.fn();
+
+      dotLottie = new DotLottie({
+        canvas,
+        src,
+      });
+      dotLottie.addEventListener('ready', onReady);
+
+      await vi.waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+    });
+
     // Skip this test in worker environment because it's not possible to mock the fetch error in worker environment
     (isWorker ? test.skip : test)('loads animation from a valid source', async () => {
       const fetch = vi.spyOn(window, 'fetch');
@@ -830,7 +845,28 @@ describe.each([
 
       expect(fetch).toHaveBeenCalledTimes(1);
 
-      expect(fetch).toHaveBeenNthCalledWith(1, src);
+      expect(fetch).toHaveBeenNthCalledWith(1, src, { signal: expect.any(AbortSignal) });
+    });
+
+    // Skip in worker environment: the worker fetches in its own thread, away from this spy
+    (isWorker ? test.skip : test)('aborts the src prefetch on destroy()', () => {
+      const fetch = vi.spyOn(window, 'fetch');
+
+      fetch.mockClear();
+
+      dotLottie = new DotLottie({
+        canvas,
+        src,
+      });
+
+      const signal = (fetch.mock.calls[0]?.[1] as RequestInit | undefined)?.signal;
+
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal?.aborted).toBe(false);
+
+      dotLottie.destroy();
+
+      expect(signal?.aborted).toBe(true);
     });
 
     test('loads lottie json file', async () => {

--- a/packages/web/tests/plugin-inline-worker.node.test.ts
+++ b/packages/web/tests/plugin-inline-worker.node.test.ts
@@ -1,0 +1,45 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, test } from 'vitest';
+
+import { pluginInlineWorker } from '../rolldown-plugins/plugin-inline-worker';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// The browser suite never runs this plugin (Vite handles ?worker&inline itself),
+// so the emitted module is guarded here.
+describe('pluginInlineWorker', () => {
+  test('embeds the worker as a parseable, byte-faithful string literal', async () => {
+    const plugin = pluginInlineWorker({ name: '@lottiefiles/dotlottie-web', version: '0.0.0-test' });
+
+    const workerPath = path.resolve(__dirname, '../src/worker/dotlottie.worker.ts');
+    const resolved = plugin.resolveId?.(`${workerPath}?worker&inline`, undefined);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.moduleSideEffects).toBe(false);
+
+    const result = await plugin.load?.(resolved?.id as string);
+
+    expect(result).not.toBeNull();
+    expect(result?.moduleSideEffects).toBe(false);
+
+    const code = result?.code as string;
+    const match = /const workerCode = (".*");/u.exec(code);
+
+    expect(match).not.toBeNull();
+
+    const workerSource = JSON.parse(match?.[1] as string) as string;
+
+    expect(workerSource.length).toBeGreaterThan(10_000);
+    expect(workerSource).toContain('postMessage');
+
+    // Blob workers decode as UTF-8; the round trip also rejects lone surrogates.
+    const bytes = new TextEncoder().encode(workerSource);
+
+    expect(new TextDecoder().decode(bytes)).toBe(workerSource);
+
+    // Syntax check on our own build output (never executed).
+    expect(() => new Function(workerSource)).not.toThrow();
+  });
+});

--- a/packages/web/tests/plugin-inline-worker.node.test.ts
+++ b/packages/web/tests/plugin-inline-worker.node.test.ts
@@ -7,28 +7,32 @@ import { pluginInlineWorker } from '../rolldown-plugins/plugin-inline-worker';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+async function emitWorkerModule(): Promise<{ code: string; workerSource: string }> {
+  const plugin = pluginInlineWorker({ name: '@lottiefiles/dotlottie-web', version: '0.0.0-test' });
+
+  const workerPath = path.resolve(__dirname, '../src/worker/dotlottie.worker.ts');
+  const resolved = plugin.resolveId?.(`${workerPath}?worker&inline`, undefined);
+
+  expect(resolved).not.toBeNull();
+  expect(resolved?.moduleSideEffects).toBe(false);
+
+  const result = await plugin.load?.(resolved?.id as string);
+
+  expect(result).not.toBeNull();
+  expect(result?.moduleSideEffects).toBe(false);
+
+  const code = result?.code as string;
+  const match = /const workerCode = (".*");/u.exec(code);
+
+  expect(match).not.toBeNull();
+
+  return { code, workerSource: JSON.parse(match?.[1] as string) as string };
+}
+
 // The browser suite never runs this plugin (Vite builds the test worker itself).
 describe('pluginInlineWorker', () => {
   test('embeds the worker as a parseable, byte-faithful string literal', async () => {
-    const plugin = pluginInlineWorker({ name: '@lottiefiles/dotlottie-web', version: '0.0.0-test' });
-
-    const workerPath = path.resolve(__dirname, '../src/worker/dotlottie.worker.ts');
-    const resolved = plugin.resolveId?.(`${workerPath}?worker&inline`, undefined);
-
-    expect(resolved).not.toBeNull();
-    expect(resolved?.moduleSideEffects).toBe(false);
-
-    const result = await plugin.load?.(resolved?.id as string);
-
-    expect(result).not.toBeNull();
-    expect(result?.moduleSideEffects).toBe(false);
-
-    const code = result?.code as string;
-    const match = /const workerCode = (".*");/u.exec(code);
-
-    expect(match).not.toBeNull();
-
-    const workerSource = JSON.parse(match?.[1] as string) as string;
+    const { workerSource } = await emitWorkerModule();
 
     expect(workerSource.length).toBeGreaterThan(10_000);
     expect(workerSource).toContain('postMessage');
@@ -38,7 +42,40 @@ describe('pluginInlineWorker', () => {
 
     expect(new TextDecoder().decode(bytes)).toBe(workerSource);
 
-    // Syntax check on our own build output (never executed).
+    // Syntax check on our own build output.
     expect(() => new Function(workerSource)).not.toThrow();
+  });
+
+  test('emitted worker source boots and answers an RPC round-trip', async () => {
+    const { workerSource } = await emitWorkerModule();
+
+    const replies: Array<{ error?: string; id: string; method: string }> = [];
+    const workerScope: {
+      onmessage: ((event: { data: unknown }) => Promise<void>) | null;
+      postMessage: (message: never) => void;
+    } = {
+      onmessage: null,
+      postMessage: (message) => replies.push(message),
+    };
+
+    const globalWithSelf = globalThis as { self?: unknown };
+    const originalSelf = globalWithSelf.self;
+
+    globalWithSelf.self = workerScope;
+
+    try {
+      // The worker bundle is an iife; evaluating it registers the RPC dispatcher.
+      new Function(workerSource)();
+
+      expect(workerScope.onmessage).toBeTypeOf('function');
+
+      await workerScope.onmessage?.({ data: { id: 'smoke', method: '__smoke__', params: {} } });
+
+      expect(replies).toEqual([
+        { id: 'smoke', method: '__smoke__', error: expect.stringContaining('not implemented') as string },
+      ]);
+    } finally {
+      globalWithSelf.self = originalSelf;
+    }
   });
 });

--- a/packages/web/tests/plugin-inline-worker.node.test.ts
+++ b/packages/web/tests/plugin-inline-worker.node.test.ts
@@ -7,8 +7,7 @@ import { pluginInlineWorker } from '../rolldown-plugins/plugin-inline-worker';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// The browser suite never runs this plugin (Vite handles ?worker&inline itself),
-// so the emitted module is guarded here.
+// The browser suite never runs this plugin (Vite builds the test worker itself).
 describe('pluginInlineWorker', () => {
   test('embeds the worker as a parseable, byte-faithful string literal', async () => {
     const plugin = pluginInlineWorker({ name: '@lottiefiles/dotlottie-web', version: '0.0.0-test' });


### PR DESCRIPTION
## Description

`dist/index.js` ended in top-level side effects (down-leveled static class fields and module-scope `createWasmLoader(...)` calls), so no bundler could tree-shake the inlined worker: importing only `DotLottie` bundled the full 341 KB raw / 37.6 KB gzip. The inlined worker was also encoded as a decimal `Uint8Array([...])` literal, 3.7x larger than the code it carries.

- Lazy singletons replace `DotLottieWorker`'s static fields and the three module-scope wasm loader calls (identical runtime semantics; workers were always spawned lazily).
- The inline-worker plugin now embeds the worker as a string literal (verified byte-identical payload).
- New node test guards the plugin output, which the browser suite never executes (Vite handles `?worker&inline` natively).

Measured (esbuild/rollup/webpack 5, minified + gzip):

| | before | after |
|---|---|---|
| `dist/index.js` | 341 KB / 37.6 KB | 151 KB / 28.6 KB |
| consumer, `DotLottie` only | 341 KB / 37.6 KB | 55 KB / 11.9 KB |
| consumer, `DotLottieWorker` only | 341 KB / 37.6 KB | ~100 KB / 18.3 KB |

Note: any future `static field = <expr>` on exported classes reintroduces the side effect and silently breaks tree-shaking (relevant to #922's `_canvasRegistry`).

## Package(s) affected

- [x] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [x] Tests have been added or updated
- [x] Changeset has been added (if applicable)