### PR TITLE
perf: fetch animation in parallel with wasm init and render once on load

### DIFF
--- a/.changeset/faster-first-frame.md
+++ b/.changeset/faster-first-frame.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+faster first frame: the animation now downloads in parallel with the WASM module instead of after it, the load path renders once instead of twice, and animation JSON is no longer parsed twice

--- a/.changeset/lazy-worker-treeshake.md
+++ b/.changeset/lazy-worker-treeshake.md
@@ -2,4 +2,4 @@
 '@lottiefiles/dotlottie-web': patch
 ---
 
-fixed bundlers not being able to tree-shake `DotLottieWorker`: apps that only use `DotLottie` no longer ship the inlined worker code (~37.6 KB → ~11.9 KB gzip)
+fixed bundlers not being able to tree-shake `DotLottieWorker`: apps that only use `DotLottie` no longer ship the inlined worker code (\~37.6 KB → \~11.9 KB gzip)

--- a/.changeset/wasm-preload.md
+++ b/.changeset/wasm-preload.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': minor
+---
+
+added `DotLottie.preload()` to start the WASM download before the first player is constructed

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -15,6 +15,7 @@
 * [Introduction](#introduction)
   * [What is dotLottie?](#what-is-dotlottie)
 * [Documentation](#documentation)
+* [Faster First Frame](#faster-first-frame)
 * [Supported Platforms](#supported-platforms)
   * [Browser Requirements](#browser-requirements)
 * [Live Examples](#live-examples)
@@ -34,6 +35,31 @@ dotLottie is an open-source file format that bundles one or more Lottie animatio
 ## Documentation
 
 To get started with `@lottiefiles/dotlottie-web`, follow the [documentation here](https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-web/).
+
+## Faster First Frame
+
+The player's WASM engine (\~500 KB compressed) is fetched from a CDN when the first player is constructed. To take that download off your first animation's critical path:
+
+```js
+import { DotLottie } from '@lottiefiles/dotlottie-web';
+
+// At app or route load, before any player is constructed:
+DotLottie.preload();
+```
+
+Or let the browser start the download even earlier (`crossorigin` is required — without it the preloaded response can't be reused and the file downloads twice):
+
+```html
+<link rel="preconnect" href="https://cdn.jsdelivr.net" />
+<link
+  rel="preload"
+  as="fetch"
+  crossorigin
+  href="https://cdn.jsdelivr.net/npm/@lottiefiles/dotlottie-web@0.77.1/dist/dotlottie-player.wasm"
+/>
+```
+
+The version in the URL must match your installed package version — the player fetches a version-pinned URL, and a mismatch means the preload can't be reused. If you use `setWasmUrl()`, call it before `preload()` and point the preload tag at the same URL.
 
 ## Supported Platforms
 

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -1985,6 +1985,14 @@ export class DotLottie {
   }
 
   /**
+   * Starts fetching and compiling the WASM module before any player is constructed.
+   * Call this at app or route load to take the WASM download off the first animation's critical path.
+   */
+  public static preload(): Promise<void> {
+    return dotLottieWasmLoader().load();
+  }
+
+  /**
    * @experimental
    * Register a custom font for use in animations
    * @param fontName - The name of the font to register

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -497,8 +497,7 @@ export class DotLottie {
     if (typeof data === 'string') {
       loaded = this._dotLottieCore.load_animation(data);
 
-      // isLottie() is a full JSON.parse of the animation; run it only on failure,
-      // to pick the more specific error message.
+      // isLottie() is a full JSON.parse; run it only on failure to pick the specific error message.
       if (!loaded && !isLottie(data)) {
         this._discardPlayerEvents();
         this._dispatchError(

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -115,7 +115,9 @@ const fitToString = (fit: string): Fit => {
 export class DotLottie {
   protected _canvas: HTMLCanvasElement | OffscreenCanvas | RenderSurface | null = null;
 
-  private _pendingLoad: { data?: Data; src?: string } | null = null;
+  private _pendingLoad: { data?: Data; dataPromise?: Promise<string | ArrayBuffer> | null; src?: string } | null = null;
+
+  private _srcFetchAbort: AbortController | null = null;
 
   protected _context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null = null;
 
@@ -188,6 +190,15 @@ export class DotLottie {
       freezeOnOffscreen: config.renderConfig?.freezeOnOffscreen ?? true,
     };
 
+    let srcPrefetch: Promise<string | ArrayBuffer> | null = null;
+
+    if (config.src && !config.data) {
+      this._srcFetchAbort = new AbortController();
+      srcPrefetch = this._fetchData(config.src, this._srcFetchAbort.signal);
+      // Errors surface via _loadFromSrc after 'ready'; this only avoids an unhandled rejection.
+      srcPrefetch.catch(() => {});
+    }
+
     this._initWasm()
       .then(() => {
         this._dotLottieCore = this._createCore();
@@ -228,9 +239,9 @@ export class DotLottie {
           }
         } else if (config.src) {
           if (this._canvas) {
-            this._loadFromSrc(config.src);
+            this._loadFromSrc(config.src, srcPrefetch);
           } else {
-            this._pendingLoad = { src: config.src };
+            this._pendingLoad = { src: config.src, dataPromise: srcPrefetch };
           }
         }
 
@@ -239,6 +250,7 @@ export class DotLottie {
         }
       })
       .catch((error) => {
+        this._srcFetchAbort?.abort();
         console.error('[dotlottie-web] Initialization failed:', error);
         this._eventManager.dispatch({
           type: 'loadError',
@@ -321,6 +333,12 @@ export class DotLottie {
         default:
           break;
       }
+    }
+  }
+
+  private _discardPlayerEvents(): void {
+    while (this._dotLottieCore?.poll_event() != null) {
+      // Drop stale core events already reported with a more specific message.
     }
   }
 
@@ -446,8 +464,8 @@ export class DotLottie {
     this._eventManager.dispatch({ type: 'loadError', error: new Error(message) });
   }
 
-  private async _fetchData(src: string): Promise<string | ArrayBuffer> {
-    const response = await fetch(src);
+  private async _fetchData(src: string, signal: AbortSignal | null = null): Promise<string | ArrayBuffer> {
+    const response = await fetch(src, { signal });
 
     if (!response.ok) {
       throw new Error(`Failed to fetch animation data from URL: ${src}. ${response.status}: ${response.statusText}`);
@@ -472,22 +490,24 @@ export class DotLottie {
       return;
     }
 
-    const width = this._canvas.width;
-    const height = this._canvas.height;
-
-    this._setupTarget(width, height);
+    this._syncCanvasSize();
+    this._setupTarget(this._canvas.width, this._canvas.height);
 
     let loaded = false;
 
     if (typeof data === 'string') {
-      if (!isLottie(data)) {
+      loaded = this._dotLottieCore.load_animation(data);
+
+      // isLottie() is a full JSON.parse of the animation; run it only on failure,
+      // to pick the more specific error message.
+      if (!loaded && !isLottie(data)) {
+        this._discardPlayerEvents();
         this._dispatchError(
           'Invalid Lottie JSON string: The provided string does not conform to the Lottie JSON format.',
         );
 
         return;
       }
-      loaded = this._dotLottieCore.load_animation(data);
     } else if (data instanceof ArrayBuffer) {
       if (!isDotLottie(data)) {
         this._dispatchError(
@@ -521,10 +541,6 @@ export class DotLottie {
     if (loaded) {
       if (this._renderConfig.quality !== undefined) {
         this._dotLottieCore.set_quality(this._renderConfig.quality);
-      }
-
-      if (IS_BROWSER) {
-        this.resize();
       }
 
       // Drain any events produced by loading (Load/LoadError).
@@ -593,8 +609,8 @@ export class DotLottie {
     }
   }
 
-  private _loadFromSrc(src: string): void {
-    this._fetchData(src)
+  private _loadFromSrc(src: string, prefetched?: Promise<string | ArrayBuffer> | null): void {
+    (prefetched ?? this._fetchData(src))
       .then((data) => this._loadFromData(data))
       .catch((error) => this._dispatchError(`Failed to load animation data from URL: ${src}. ${error}`));
   }
@@ -1284,6 +1300,10 @@ export class DotLottie {
 
     this._cleanupCanvas();
 
+    this._srcFetchAbort?.abort();
+    this._srcFetchAbort = null;
+    this._pendingLoad = null;
+
     const core = this._dotLottieCore;
 
     this._dotLottieCore = null;
@@ -1337,19 +1357,23 @@ export class DotLottie {
    * Recalculates and updates canvas dimensions based on current size.
    * Call this when the canvas container size changes to maintain proper rendering. Usually handled by autoResize.
    */
+  private _syncCanvasSize(): void {
+    if (!(IS_BROWSER && this._canvas instanceof HTMLCanvasElement)) return;
+
+    const dpr = this._renderConfig.devicePixelRatio || window.devicePixelRatio || 1;
+
+    const { height: clientHeight, width: clientWidth } = this._canvas.getBoundingClientRect();
+
+    if (clientHeight !== 0 && clientWidth !== 0) {
+      this._canvas.width = clientWidth * dpr;
+      this._canvas.height = clientHeight * dpr;
+    }
+  }
+
   public resize(): void {
     if (!this._dotLottieCore || !this.isLoaded || !this._canvas) return;
 
-    if (IS_BROWSER && this._canvas instanceof HTMLCanvasElement) {
-      const dpr = this._renderConfig.devicePixelRatio || window.devicePixelRatio || 1;
-
-      const { height: clientHeight, width: clientWidth } = this._canvas.getBoundingClientRect();
-
-      if (clientHeight !== 0 && clientWidth !== 0) {
-        this._canvas.width = clientWidth * dpr;
-        this._canvas.height = clientHeight * dpr;
-      }
-    }
+    this._syncCanvasSize();
 
     const resized = this._setupTarget(this._canvas.width, this._canvas.height);
 
@@ -1384,7 +1408,7 @@ export class DotLottie {
       if (pending.data) {
         this._loadFromData(pending.data);
       } else if (pending.src) {
-        this._loadFromSrc(pending.src);
+        this._loadFromSrc(pending.src, pending.dataPromise);
       }
     }
   }
@@ -1508,6 +1532,7 @@ export class DotLottie {
   public loadAnimation(animationId: string): void {
     if (this._dotLottieCore === null || this._dotLottieCore.animation_id() === animationId || !this._canvas) return;
 
+    this._syncCanvasSize();
     this._setupTarget(this._canvas.width, this._canvas.height);
     const loaded = this._dotLottieCore.load_animation_from_id(animationId);
 
@@ -1515,7 +1540,6 @@ export class DotLottie {
       if (this._renderConfig.quality !== undefined) {
         this._dotLottieCore.set_quality(this._renderConfig.quality);
       }
-      this.resize();
       this._drainPlayerEvents();
 
       this._dotLottieCore.render();

--- a/packages/web/src/webgl/dotlottie-webgl.ts
+++ b/packages/web/src/webgl/dotlottie-webgl.ts
@@ -96,4 +96,12 @@ export class DotLottieWebGL extends DotLottie {
   public static override setWasmUrl(url: string): void {
     webGLWasmLoader().setWasmUrl(url);
   }
+
+  /**
+   * Starts fetching and compiling the WASM module before any player is constructed.
+   * Call this at app or route load to take the WASM download off the first animation's critical path.
+   */
+  public static override preload(): Promise<void> {
+    return webGLWasmLoader().load();
+  }
 }

--- a/packages/web/src/webgpu/dotlottie-webgpu.ts
+++ b/packages/web/src/webgpu/dotlottie-webgpu.ts
@@ -182,4 +182,12 @@ export class DotLottieWebGPU extends DotLottie {
   public static override setWasmUrl(url: string): void {
     webGPUWasmLoader().setWasmUrl(url);
   }
+
+  /**
+   * Starts fetching and compiling the WASM module before any player is constructed.
+   * Call this at app or route load to take the WASM download off the first animation's critical path.
+   */
+  public static override preload(): Promise<void> {
+    return webGPUWasmLoader().load();
+  }
 }

--- a/packages/web/tests/dotlottie.test.ts
+++ b/packages/web/tests/dotlottie.test.ts
@@ -801,6 +801,21 @@ describe.each([
   });
 
   describe('load', () => {
+    // preload() exists on the main-thread player only
+    (isWorker ? test.skip : test)('preload() warms the wasm module before construction', async () => {
+      await expect(DotLottieClass.preload()).resolves.toBeUndefined();
+
+      const onReady = vi.fn();
+
+      dotLottie = new DotLottie({
+        canvas,
+        src,
+      });
+      dotLottie.addEventListener('ready', onReady);
+
+      await vi.waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+    });
+
     // Skip this test in worker environment because it's not possible to mock the fetch error in worker environment
     (isWorker ? test.skip : test)('loads animation from a valid source', async () => {
       const fetch = vi.spyOn(window, 'fetch');

--- a/packages/web/tests/dotlottie.test.ts
+++ b/packages/web/tests/dotlottie.test.ts
@@ -830,7 +830,28 @@ describe.each([
 
       expect(fetch).toHaveBeenCalledTimes(1);
 
-      expect(fetch).toHaveBeenNthCalledWith(1, src);
+      expect(fetch).toHaveBeenNthCalledWith(1, src, { signal: expect.any(AbortSignal) });
+    });
+
+    // Skip in worker environment: the worker fetches in its own thread, away from this spy
+    (isWorker ? test.skip : test)('aborts the src prefetch on destroy()', () => {
+      const fetch = vi.spyOn(window, 'fetch');
+
+      fetch.mockClear();
+
+      dotLottie = new DotLottie({
+        canvas,
+        src,
+      });
+
+      const signal = (fetch.mock.calls[0]?.[1] as RequestInit | undefined)?.signal;
+
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal?.aborted).toBe(false);
+
+      dotLottie.destroy();
+
+      expect(signal?.aborted).toBe(true);
     });
 
     test('loads lottie json file', async () => {


### PR DESCRIPTION
## Description

Cold first frame was `wasm fetch+compile → animation fetch → parse → render ×2`. Now:

- `config.src` downloads in parallel with WASM init (aborted on `destroy()`); event order is unchanged — loading still starts only after `ready`.
- The load path sizes the canvas once before target setup instead of setting up at a stale size and re-rendering through `resize()` — one render per load instead of two, and no forced layout.
- `isLottie()` (a full `JSON.parse`) runs only when the core rejects the string, purely to pick the specific error message.

Measured with simulated CDN delays (WASM 400 ms, animation 250 ms), Chromium, median of 7: first render **705 ms → 440 ms**. Full suite green; new test covers the prefetch abort.

Stacked on #925.

## Package(s) affected

- [x] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [x] Tests have been added or updated
- [x] Changeset has been added (if applicable)