### PR TITLE
feat: add DotLottie.preload() for warming the wasm module

### DIFF
--- a/.changeset/wasm-preload.md
+++ b/.changeset/wasm-preload.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': minor
+---
+
+added `DotLottie.preload()` to start the WASM download before the first player is constructed

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -15,6 +15,7 @@
 * [Introduction](#introduction)
   * [What is dotLottie?](#what-is-dotlottie)
 * [Documentation](#documentation)
+* [Faster First Frame](#faster-first-frame)
 * [Supported Platforms](#supported-platforms)
   * [Browser Requirements](#browser-requirements)
 * [Live Examples](#live-examples)
@@ -34,6 +35,31 @@ dotLottie is an open-source file format that bundles one or more Lottie animatio
 ## Documentation
 
 To get started with `@lottiefiles/dotlottie-web`, follow the [documentation here](https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-web/).
+
+## Faster First Frame
+
+The player's WASM engine (~500 KB compressed) is fetched from a CDN when the first player is constructed. To take that download off your first animation's critical path:
+
+```js
+import { DotLottie } from '@lottiefiles/dotlottie-web';
+
+// At app or route load, before any player is constructed:
+DotLottie.preload();
+```
+
+Or let the browser start the download even earlier (`crossorigin` is required — without it the preloaded response can't be reused and the file downloads twice):
+
+```html
+<link rel="preconnect" href="https://cdn.jsdelivr.net" />
+<link
+  rel="preload"
+  as="fetch"
+  crossorigin
+  href="https://cdn.jsdelivr.net/npm/@lottiefiles/dotlottie-web@0.77.1/dist/dotlottie-player.wasm"
+/>
+```
+
+The version in the URL must match your installed package version — the player fetches a version-pinned URL, and a mismatch means the preload can't be reused. If you use `setWasmUrl()`, call it before `preload()` and point the preload tag at the same URL.
 
 ## Supported Platforms
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -38,7 +38,7 @@ To get started with `@lottiefiles/dotlottie-web`, follow the [documentation here
 
 ## Faster First Frame
 
-The player's WASM engine (~500 KB compressed) is fetched from a CDN when the first player is constructed. To take that download off your first animation's critical path:
+The player's WASM engine (\~500 KB compressed) is fetched from a CDN when the first player is constructed. To take that download off your first animation's critical path:
 
 ```js
 import { DotLottie } from '@lottiefiles/dotlottie-web';

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -1987,6 +1987,14 @@ export class DotLottie {
   }
 
   /**
+   * Starts fetching and compiling the WASM module before any player is constructed.
+   * Call this at app or route load to take the WASM download off the first animation's critical path.
+   */
+  public static preload(): Promise<void> {
+    return dotLottieWasmLoader().load();
+  }
+
+  /**
    * @experimental
    * Register a custom font for use in animations
    * @param fontName - The name of the font to register

--- a/packages/web/src/webgl/dotlottie-webgl.ts
+++ b/packages/web/src/webgl/dotlottie-webgl.ts
@@ -97,4 +97,12 @@ export class DotLottieWebGL extends DotLottie {
   public static override setWasmUrl(url: string): void {
     webGLWasmLoader().setWasmUrl(url);
   }
+
+  /**
+   * Starts fetching and compiling the WASM module before any player is constructed.
+   * Call this at app or route load to take the WASM download off the first animation's critical path.
+   */
+  public static override preload(): Promise<void> {
+    return webGLWasmLoader().load();
+  }
 }

--- a/packages/web/src/webgpu/dotlottie-webgpu.ts
+++ b/packages/web/src/webgpu/dotlottie-webgpu.ts
@@ -183,4 +183,12 @@ export class DotLottieWebGPU extends DotLottie {
   public static override setWasmUrl(url: string): void {
     webGPUWasmLoader().setWasmUrl(url);
   }
+
+  /**
+   * Starts fetching and compiling the WASM module before any player is constructed.
+   * Call this at app or route load to take the WASM download off the first animation's critical path.
+   */
+  public static override preload(): Promise<void> {
+    return webGPUWasmLoader().load();
+  }
 }

--- a/packages/web/tests/dotlottie.test.ts
+++ b/packages/web/tests/dotlottie.test.ts
@@ -801,6 +801,21 @@ describe.each([
   });
 
   describe('load', () => {
+    // preload() exists on the main-thread player only
+    (isWorker ? test.skip : test)('preload() warms the wasm module before construction', async () => {
+      await expect(DotLottieClass.preload()).resolves.toBeUndefined();
+
+      const onReady = vi.fn();
+
+      dotLottie = new DotLottie({
+        canvas,
+        src,
+      });
+      dotLottie.addEventListener('ready', onReady);
+
+      await vi.waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+    });
+
     // Skip this test in worker environment because it's not possible to mock the fetch error in worker environment
     (isWorker ? test.skip : test)('loads animation from a valid source', async () => {
       const fetch = vi.spyOn(window, 'fetch');


### PR DESCRIPTION
## Description

Adds `static preload()` to `DotLottie` (and the WebGL/WebGPU subclasses) so apps can start the WASM fetch + compile at route load, before any player is constructed — taking ~100–400 ms off the first animation's cold start. README gains a "Faster First Frame" section covering `preload()`, `<link rel="preload" as="fetch" crossorigin>` (with the version-pinning and `crossorigin` gotchas), and a jsdelivr `preconnect` hint.

Stacked on #926.

## Package(s) affected

- [x] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [x] Tests have been added or updated
- [x] Changeset has been added (if applicable)