### PR TITLE
perf: make wc CDN bundles self-contained and drop worker code from dotlottie-wc

### DIFF
--- a/.changeset/wc-standalone-bundles.md
+++ b/.changeset/wc-standalone-bundles.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-wc': patch
+---
+
+each CDN bundle is now self-contained: `dotlottie-wc.js` no longer downloads the worker code (one \~19 KB gzip file instead of \~36 KB across three)

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -24,9 +24,22 @@ export default [
     import: '*',
   },
   {
+    name: '@lottiefiles/dotlottie-web (DotLottie only)',
+    path: 'packages/web/dist/index.js',
+    import: '{ DotLottie }',
+  },
+  {
     name: '@lottiefiles/dotlottie-wc',
     path: 'packages/wc/dist/index.js',
     import: '*',
+  },
+  {
+    name: '@lottiefiles/dotlottie-wc CDN',
+    path: 'packages/wc/dist/dotlottie-wc.js',
+  },
+  {
+    name: '@lottiefiles/dotlottie-wc worker CDN',
+    path: 'packages/wc/dist/dotlottie-worker-wc.js',
   },
   {
     name: '@lottiefiles/dotlottie-svelte',

--- a/packages/wc/src/dotlottie-wc.ts
+++ b/packages/wc/src/dotlottie-wc.ts
@@ -5,7 +5,9 @@ import { customElement } from 'lit/decorators.js';
 
 import { BaseDotLottieWC } from './base-dotlottie-wc';
 
-export { setWasmUrl } from './set-wasm-url';
+export const setWasmUrl = (url: string): void => {
+  DotLottie.setWasmUrl(url);
+};
 
 @customElement('dotlottie-wc')
 export class DotLottieWC extends BaseDotLottieWC<DotLottie> {

--- a/packages/wc/src/dotlottie-worker-wc.ts
+++ b/packages/wc/src/dotlottie-worker-wc.ts
@@ -5,7 +5,9 @@ import { customElement } from 'lit/decorators.js';
 
 import { BaseDotLottieWC } from './base-dotlottie-wc';
 
-export { setWasmUrl } from './set-wasm-url';
+export const setWasmUrl = (url: string): void => {
+  DotLottieWorker.setWasmUrl(url);
+};
 
 @customElement('dotlottie-worker-wc')
 export class DotLottieWorkerWC extends BaseDotLottieWC<DotLottieWorker> {

--- a/packages/wc/src/index.ts
+++ b/packages/wc/src/index.ts
@@ -1,3 +1,4 @@
 export * from './dotlottie-wc';
 export * from './dotlottie-worker-wc';
-export * from './set-wasm-url';
+// Explicit: the per-entry setWasmUrl exports conflict under `export *`; this one sets both players.
+export { setWasmUrl } from './set-wasm-url';

--- a/packages/wc/tsdown.config.ts
+++ b/packages/wc/tsdown.config.ts
@@ -14,10 +14,16 @@ const config: UserConfig = {
   tsconfig: 'tsconfig.build.json',
 };
 
+// set-wasm-url is not an entry: a self-contained copy would configure its own module
+// state, not the player bundles'. index.ts inlines it.
+const ENTRIES = ['base-dotlottie-wc', 'dotlottie-wc', 'dotlottie-worker-wc', 'index'];
+
 export default defineConfig([
-  // Self-contained JS bundle (usable via CDN); .d.ts is emitted by the config below.
-  {
+  // One self-contained bundle per entry: a combined build hoists shared code into one
+  // chunk, putting worker code in the DotLottie-only bundle.
+  ...ENTRIES.map((entry) => ({
     ...config,
+    entry: [`./src/${entry}.ts`],
     dts: false,
     // Regex (not bare names) so sub-path exports like lit/decorators.js are bundled too.
     deps: {
@@ -25,7 +31,7 @@ export default defineConfig([
         (dep) => new RegExp(`^${dep.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}($|/)`),
       ),
     },
-  },
+  })),
   // Declarations only, deps kept external so the .d.ts references '@lottiefiles/dotlottie-web'
   // instead of inlining its type-only `Config` export (rolldown-plugin-dts rejects as MISSING_EXPORT).
   {


### PR DESCRIPTION
## Description

Re-lands #928, which was merged into `feat/wasm-preload` after that branch had already been folded down the stack — so its changes never reached #925 or `main`. This is a clean cherry-pick of f1a9b22 onto `main`; original description below.

The wc entries were built together, so rolldown hoisted everything either element needs into one shared chunk — `dotlottie-wc.js` users downloaded the worker code and `DotLottieWorker` too. Now:

- Each entry's `setWasmUrl` configures only its own player (`set-wasm-url.ts` still sets both, inlined into `index.js`).
- Each CDN bundle builds self-contained. `dotlottie-wc.js`: one 78 KB / 19 KB gzip file with no worker code, vs ~173 KB / 36 KB gzip across three files before.
- `dist/set-wasm-url.js` is no longer emitted: a self-contained copy would configure its own module state, not the player bundles'. It was never documented or exported.

Tradeoff: a page loading both `dotlottie-wc.js` and `dotlottie-worker-wc.js` now downloads two self-contained copies (~205 KB combined vs ~173 KB shared) — the single-element case is far more common.

Also adds Bundle Size entries so CI tracks what this stack optimized: a `DotLottie`-only import of the core package and the two wc CDN files.

Verified on this branch: web + wc builds green (verify-dist ok), wc suite 47 passed, size-limit resolves all entries (`dotlottie-wc` CDN 16.78 KB brotli).

## Package(s) affected

- [ ] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [x] `@lottiefiles/dotlottie-wc`

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [x] Tests have been added or updated
- [x] Changeset has been added (if applicable)