### PR TITLE
refactor: replace JSON.parse in isLottie with a cheap shape check

### DIFF
--- a/.changeset/lottie-check-no-parse.md
+++ b/.changeset/lottie-check-no-parse.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+refactor: replace `JSON.parse` in `isLottie` with a cheap shape check

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -497,7 +497,6 @@ export class DotLottie {
     if (typeof data === 'string') {
       loaded = this._dotLottieCore.load_animation(data);
 
-      // isLottie() is a full JSON.parse; run it only on failure to pick the specific error message.
       if (!loaded && !isLottie(data)) {
         this._discardPlayerEvents();
         this._dispatchError(

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -80,21 +80,17 @@ export function isLottieJSON(json: Record<string, unknown>): boolean {
 }
 
 /**
- * Detects if data is a valid Lottie animation by checking for required JSON fields.
- * Accepts either a JSON string or a parsed object.
+ * Detects if data is likely a Lottie animation. Strings are only checked for JSON-object shape;
+ * full parsing and validation is left to the core.
  * @param fileData - Lottie data as JSON string or parsed object
- * @returns True if data contains required Lottie fields, false otherwise
+ * @returns True if data looks like Lottie JSON, false otherwise
  */
 export function isLottie(fileData: string | Record<string, unknown>): boolean {
   if (typeof fileData === 'string') {
-    try {
-      return isLottieJSON(JSON.parse(fileData));
-    } catch (_e) {
-      return false;
-    }
-  } else {
-    return isLottieJSON(fileData);
+    return /^\s*\{/u.test(fileData) && /\}\s*$/u.test(fileData);
   }
+
+  return isLottieJSON(fileData);
 }
 
 /**

--- a/packages/web/tests/dotlottie.test.ts
+++ b/packages/web/tests/dotlottie.test.ts
@@ -1042,7 +1042,7 @@ describe.each([
 
       dotLottie = new DotLottie({
         canvas,
-        data: JSON.stringify({}),
+        data: 'not a lottie animation',
       });
 
       dotLottie.addEventListener('loadError', onLoadError);
@@ -1055,6 +1055,23 @@ describe.each([
         type: 'loadError',
         error: new Error('Invalid Lottie JSON string: The provided string does not conform to the Lottie JSON format.'),
       });
+
+      expect(dotLottie.isLoaded).toBe(false);
+    });
+
+    test('emit loadError event when loading valid JSON that is not a lottie animation', async () => {
+      const onLoadError = vi.fn();
+
+      dotLottie = new DotLottie({
+        canvas,
+        data: JSON.stringify({}),
+      });
+
+      dotLottie.addEventListener('loadError', onLoadError);
+
+      expect(dotLottie.isLoaded).toBe(false);
+
+      await vi.waitFor(() => expect(onLoadError).toHaveBeenCalledTimes(1));
 
       expect(dotLottie.isLoaded).toBe(false);
     });

--- a/packages/web/tests/utils.test.ts
+++ b/packages/web/tests/utils.test.ts
@@ -79,10 +79,17 @@ describe('isLottie', () => {
 
   test.each([
     [validLottieJSON, true],
-    [invalidLottieJSON, false],
+    [invalidLottieJSON, true],
+    ['{not even valid json}', true],
+    ['  \n\t {"v":"5.5.9"} \n ', true],
     [validLottieObject, true],
     [invalidLottieObject, false],
     ['invalid string', false],
+    ['[0, 1, 2]', false],
+    ['<!DOCTYPE html><html><body>404</body></html>', false],
+    ['', false],
+    ['   ', false],
+    ['{', false],
   ])('returns %s for %s', (fileData, expected) => {
     expect(isLottie(fileData)).toBe(expected);
   });


### PR DESCRIPTION
`isLottie` no longer runs a full `JSON.parse` on animation strings. It now checks JSON-object shape (`{...}`) and leaves full parsing and validation to the core, which already parses the data and reports load failures. The check only picks an error message on the failure path, so strict field validation there was redundant work.