### PR TITLE
chore: point npm homepages at docs, add animation-library CTA to READMEs

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,5 +1,9 @@
 # @lottiefiles/dotlottie-react
 
+> [!TIP]
+> Looking for animations to use with this player? Browse **[100,000+ free Lottie animations](https://lottiefiles.com/free-animations?utm_source=npm&utm_medium=readme)** and grab any of them as `.lottie` or `.json`, or create your own with [Lottie Creator](https://lottiefiles.com/lottie-creator?utm_source=npm&utm_medium=readme).
+
+
 ![npm](https://img.shields.io/npm/v/@lottiefiles/dotlottie-react)
 ![npm bundle size](https://img.shields.io/bundlephobia/minzip/%40lottiefiles%2Fdotlottie-react)
 ![npm](https://img.shields.io/npm/dt/%40lottiefiles/dotlottie-react)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/LottieFiles/dotlottie-web.git",
     "directory": "packages/react"
   },
-  "homepage": "https://github.com/LottieFiles/dotlottie-web#readme",
+  "homepage": "https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-react/?utm_source=npm&utm_medium=package",
   "bugs": "https://github.com/LottieFiles/dotlottie-web/issues",
   "author": "LottieFiles",
   "contributors": [

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,5 +1,9 @@
 # @lottiefiles/dotlottie-solid
 
+> [!TIP]
+> Looking for animations to use with this player? Browse **[100,000+ free Lottie animations](https://lottiefiles.com/free-animations?utm_source=npm&utm_medium=readme)** and grab any of them as `.lottie` or `.json`, or create your own with [Lottie Creator](https://lottiefiles.com/lottie-creator?utm_source=npm&utm_medium=readme).
+
+
 <p align="center">
   <img src="https://lottie.host/43f43646-b018-4d72-a96b-02a929cd9727/gARxdIetbE.svg" alt="dotLottie Web" width="550" />
 </p>

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/LottieFiles/dotlottie-web.git",
     "directory": "packages/solid"
   },
-  "homepage": "https://github.com/LottieFiles/dotlottie-web#readme",
+  "homepage": "https://developers.lottiefiles.com/docs/dotlottie-player/?utm_source=npm&utm_medium=package",
   "bugs": "https://github.com/LottieFiles/dotlottie-web/issues",
   "author": "LottieFiles",
   "contributors": [],

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,5 +1,9 @@
 # @lottiefiles/dotlottie-svelte
 
+> [!TIP]
+> Looking for animations to use with this player? Browse **[100,000+ free Lottie animations](https://lottiefiles.com/free-animations?utm_source=npm&utm_medium=readme)** and grab any of them as `.lottie` or `.json`, or create your own with [Lottie Creator](https://lottiefiles.com/lottie-creator?utm_source=npm&utm_medium=readme).
+
+
 ![npm](https://img.shields.io/npm/v/@lottiefiles/dotlottie-svelte)
 ![npm bundle size](https://img.shields.io/bundlephobia/minzip/%40lottiefiles%2Fdotlottie-svelte)
 ![npm](https://img.shields.io/npm/dt/%40lottiefiles/dotlottie-svelte)

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/LottieFiles/dotlottie-web.git",
     "directory": "packages/svelte"
   },
-  "homepage": "https://github.com/LottieFiles/dotlottie-web#readme",
+  "homepage": "https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-svelte/?utm_source=npm&utm_medium=package",
   "bugs": "https://github.com/LottieFiles/dotlottie-web/issues",
   "author": "LottieFiles",
   "contributors": [

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,5 +1,9 @@
 # @lottiefiles/dotlottie-vue
 
+> [!TIP]
+> Looking for animations to use with this player? Browse **[100,000+ free Lottie animations](https://lottiefiles.com/free-animations?utm_source=npm&utm_medium=readme)** and grab any of them as `.lottie` or `.json`, or create your own with [Lottie Creator](https://lottiefiles.com/lottie-creator?utm_source=npm&utm_medium=readme).
+
+
 ![npm](https://img.shields.io/npm/v/@lottiefiles/dotlottie-vue)
 ![npm bundle size](https://img.shields.io/bundlephobia/minzip/%40lottiefiles%2Fdotlottie-vue)
 ![npm](https://img.shields.io/npm/dt/%40lottiefiles/dotlottie-vue)

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/LottieFiles/dotlottie-web.git",
     "directory": "packages/vue"
   },
-  "homepage": "https://github.com/LottieFiles/dotlottie-web#readme",
+  "homepage": "https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-vue/?utm_source=npm&utm_medium=package",
   "bugs": "https://github.com/LottieFiles/dotlottie-web/issues",
   "author": "LottieFiles",
   "contributors": [

--- a/packages/wc/README.md
+++ b/packages/wc/README.md
@@ -1,5 +1,9 @@
 # @lottiefiles/dotlottie-wc
 
+> [!TIP]
+> Looking for animations to use with this player? Browse **[100,000+ free Lottie animations](https://lottiefiles.com/free-animations?utm_source=npm&utm_medium=readme)** and grab any of them as `.lottie` or `.json`, or create your own with [Lottie Creator](https://lottiefiles.com/lottie-creator?utm_source=npm&utm_medium=readme).
+
+
 ![npm](https://img.shields.io/npm/v/@lottiefiles/dotlottie-wc)
 ![npm bundle size](https://img.shields.io/bundlephobia/minzip/%40lottiefiles%2Fdotlottie-wc)
 ![npm](https://img.shields.io/npm/dt/%40lottiefiles%2Fdotlottie-wc)

--- a/packages/wc/package.json
+++ b/packages/wc/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/LottieFiles/dotlottie-web.git",
     "directory": "packages/wc"
   },
-  "homepage": "https://github.com/LottieFiles/dotlottie-web#readme",
+  "homepage": "https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-wc/?utm_source=npm&utm_medium=package",
   "bugs": "https://github.com/LottieFiles/dotlottie-web/issues",
   "author": "LottieFiles",
   "contributors": [

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,5 +1,9 @@
 # @lottiefiles/dotlottie-web
 
+> [!TIP]
+> Looking for animations to use with this player? Browse **[100,000+ free Lottie animations](https://lottiefiles.com/free-animations?utm_source=npm&utm_medium=readme)** and grab any of them as `.lottie` or `.json`, or create your own with [Lottie Creator](https://lottiefiles.com/lottie-creator?utm_source=npm&utm_medium=readme).
+
+
 ![npm](https://img.shields.io/npm/v/@lottiefiles/dotlottie-web)
 ![npm bundle size](https://img.shields.io/bundlephobia/minzip/@lottiefiles/dotlottie-web)
 ![npm](https://img.shields.io/npm/dw/@lottiefiles/dotlottie-web)

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/LottieFiles/dotlottie-web.git",
     "directory": "packages/web"
   },
-  "homepage": "https://github.com/LottieFiles/dotlottie-web#readme",
+  "homepage": "https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-web/?utm_source=npm&utm_medium=package",
   "bugs": "https://github.com/LottieFiles/dotlottie-web/issues",
   "author": "LottieFiles",
   "contributors": [


### PR DESCRIPTION
Part of the SEO/distribution workstream (lottiefiles.com traffic):

- `homepage` in each package.json now points to the package's developers.lottiefiles.com docs page (with `utm_source=npm`) instead of the GitHub README — npm's *Homepage* link becomes a funnel into our own properties. (`solid` points at the docs index; it has no dedicated docs page yet — 404 checked.)
- Each package README gets one `> [!TIP]` callout under the title linking the free animation library and Lottie Creator with UTMs. These READMEs render on npmjs.com package pages (6.2M downloads/mo on dotlottie-web alone) which also rank in Google for player-related queries.

No code changes; next `npm publish` of each package picks up the new metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)