### PR TITLE
docs: refresh dotLottie links and point homepages at runtime docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <b>dotLottie</b> (<code>.lottie</code>) animations on the web — a Rust + WASM core
   powered by <a href="https://github.com/thorvg/thorvg">ThorVG</a>, with Software,
   WebGL2, and WebGPU rendering backends and full
-  <a href="https://dotlottie.io/">dotLottie v2</a> support (theming, state machines,
+  <a href="https://lottiefiles.com/dotlottie">dotLottie v2</a> support (theming, state machines,
   and audio).
 </p>
 
@@ -28,7 +28,7 @@
 
 # Why dotLottie Web
 
-* 📦 **Lottie + dotLottie, one player** — point `src` at a classic Lottie [`.json`](https://lottiefiles.github.io/lottie-docs/) or a [`.lottie`](https://dotlottie.io/) archive. The `.lottie` format bundles multiple animations, themes, state machines, and embedded assets into a single compressed file.
+* 📦 **Lottie + dotLottie, one player** — point `src` at a classic Lottie [`.json`](https://lottiefiles.github.io/lottie-docs/) or a [`.lottie`](https://lottiefiles.com/dotlottie) archive. The `.lottie` format bundles multiple animations, themes, state machines, and embedded assets into a single compressed file.
 * 🦀 **Rust + WASM core** — powered by [`dotlottie-rs`](https://github.com/LottieFiles/dotlottie-rs), the same engine that ships in iOS, Android, and native dotLottie players. One battle-tested implementation across every platform.
 * 🎨 **ThorVG renderer** — an industrial-grade vector graphics engine with the broadest Lottie feature coverage of any web renderer. See the [ThorVG Lottie support matrix](https://github.com/thorvg/thorvg/wiki/Lottie-Support).
 * ⚡ **Three rendering backends** — Software (Canvas2D), WebGL2, and WebGPU (experimental). Switch with a one-line import change — same `DotLottie` class everywhere.

--- a/guidelines/README.md
+++ b/guidelines/README.md
@@ -52,5 +52,5 @@ Found an issue or want to improve the guidelines? PRs welcome!
 
 * [dotLottie Documentation](https://developers.lottiefiles.com/docs/dotlottie-player)
 * [dotlottie-web GitHub](https://github.com/LottieFiles/dotlottie-web)
-* [dotLottie Format](https://dotlottie.io)
+* [dotLottie Format](https://lottiefiles.com/dotlottie)
 * [LottieFiles Creator](https://creators.lottiefiles.com)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -31,13 +31,13 @@
 
 ## Introduction
 
-A React library for rendering [lottie](https://lottiefiles.github.io/lottie-docs/) and [dotLottie](https://dotlottie.io) animations in the browser.
+A React library for rendering [lottie](https://lottiefiles.github.io/lottie-docs/) and [dotLottie](https://lottiefiles.com/dotlottie) animations in the browser.
 
 ### What is dotLottie?
 
 dotLottie is an open-source file format that aggregates one or more Lottie files and their associated resources into a single file. They are ZIP archives compressed with the Deflate compression method and carry the file extension of ".lottie".
 
-[Learn more about dotLottie](https://dotlottie.io/).
+[Learn more about dotLottie](https://lottiefiles.com/dotlottie).
 
 ## Installation
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/LottieFiles/dotlottie-web.git",
     "directory": "packages/react"
   },
-  "homepage": "https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-react/?utm_source=npm&utm_medium=package",
+  "homepage": "https://docs.lottiefiles.com/en/runtimes/distributions/react?utm_source=npm&utm_medium=package",
   "bugs": "https://github.com/LottieFiles/dotlottie-web/issues",
   "author": "LottieFiles",
   "contributors": [

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -26,13 +26,13 @@
 
 ## Introduction
 
-A Solid library for rendering [lottie](https://lottiefiles.github.io/lottie-docs/) and [dotLottie](https://dotlottie.io) animations in the browser.
+A Solid library for rendering [lottie](https://lottiefiles.github.io/lottie-docs/) and [dotLottie](https://lottiefiles.com/dotlottie) animations in the browser.
 
 ### What is dotLottie?
 
 dotLottie is an open-source file format that aggregates one or more Lottie files and their associated resources into a single file. They are ZIP archives compressed with the Deflate compression method and carry the file extension of ".lottie".
 
-[Learn more about dotLottie](https://dotlottie.io/).
+[Learn more about dotLottie](https://lottiefiles.com/dotlottie).
 
 ## Installation
 

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/LottieFiles/dotlottie-web.git",
     "directory": "packages/solid"
   },
-  "homepage": "https://developers.lottiefiles.com/docs/dotlottie-player/?utm_source=npm&utm_medium=package",
+  "homepage": "https://docs.lottiefiles.com/en/runtimes?utm_source=npm&utm_medium=package",
   "bugs": "https://github.com/LottieFiles/dotlottie-web/issues",
   "author": "LottieFiles",
   "contributors": [],

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -31,13 +31,13 @@
 
 ## Introduction
 
-A Svelte component for rendering [Lottie](https://lottiefiles.github.io/lottie-docs/) and [dotLottie](https://dotlottie.io) animations. It acts as a wrapper around the [`dotLottie`](../web/README.md) web player.
+A Svelte component for rendering [Lottie](https://lottiefiles.github.io/lottie-docs/) and [dotLottie](https://lottiefiles.com/dotlottie) animations. It acts as a wrapper around the [`dotLottie`](../web/README.md) web player.
 
 ### What is dotLottie?
 
 dotLottie is an open-source file format that aggregates one or more Lottie files and their associated resources into a single file. They are ZIP archives compressed with the Deflate compression method and carry the file extension of ".lottie".
 
-[Learn more about dotLottie](https://dotlottie.io/).
+[Learn more about dotLottie](https://lottiefiles.com/dotlottie).
 
 ## Installation
 

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/LottieFiles/dotlottie-web.git",
     "directory": "packages/svelte"
   },
-  "homepage": "https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-svelte/?utm_source=npm&utm_medium=package",
+  "homepage": "https://docs.lottiefiles.com/en/runtimes/distributions/svelte?utm_source=npm&utm_medium=package",
   "bugs": "https://github.com/LottieFiles/dotlottie-web/issues",
   "author": "LottieFiles",
   "contributors": [

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -30,13 +30,13 @@
 
 ## Introduction
 
-A Vue library for rendering [lottie](https://lottiefiles.github.io/lottie-docs/) and [dotLottie](https://dotlottie.io) animations in the browser.
+A Vue library for rendering [lottie](https://lottiefiles.github.io/lottie-docs/) and [dotLottie](https://lottiefiles.com/dotlottie) animations in the browser.
 
 ### What is dotLottie?
 
 dotLottie is an open-source file format that aggregates one or more Lottie files and their associated resources into a single file. They are ZIP archives compressed with the Deflate compression method and carry the file extension of ".lottie".
 
-[Learn more about dotLottie](https://dotlottie.io/).
+[Learn more about dotLottie](https://lottiefiles.com/dotlottie).
 
 ## Installation
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/LottieFiles/dotlottie-web.git",
     "directory": "packages/vue"
   },
-  "homepage": "https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-vue/?utm_source=npm&utm_medium=package",
+  "homepage": "https://docs.lottiefiles.com/en/runtimes/distributions/vue?utm_source=npm&utm_medium=package",
   "bugs": "https://github.com/LottieFiles/dotlottie-web/issues",
   "author": "LottieFiles",
   "contributors": [

--- a/packages/wc/README.md
+++ b/packages/wc/README.md
@@ -33,13 +33,13 @@
 
 ## Introduction
 
-A web component for rendering and playing [Lottie](https://lottiefiles.github.io/lottie-docs/) and [DotLottie](https://dotlottie.io) animations in web applications.
+A web component for rendering and playing [Lottie](https://lottiefiles.github.io/lottie-docs/) and [DotLottie](https://lottiefiles.com/dotlottie) animations in web applications.
 
 ### What is dotLottie?
 
 dotLottie is an open-source file format that aggregates one or more Lottie files and their associated resources into a single file. They are ZIP archives compressed with the Deflate compression method and carry the file extension of ".lottie".
 
-[Learn more about dotLottie](https://dotlottie.io/).
+[Learn more about dotLottie](https://lottiefiles.com/dotlottie).
 
 ## Installation
 

--- a/packages/wc/package.json
+++ b/packages/wc/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/LottieFiles/dotlottie-web.git",
     "directory": "packages/wc"
   },
-  "homepage": "https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-wc/?utm_source=npm&utm_medium=package",
+  "homepage": "https://docs.lottiefiles.com/en/runtimes/distributions/web-component?utm_source=npm&utm_medium=package",
   "bugs": "https://github.com/LottieFiles/dotlottie-web/issues",
   "author": "LottieFiles",
   "contributors": [

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -28,13 +28,13 @@
 
 ## Introduction
 
-`@lottiefiles/dotlottie-web` is a JavaScript library for rendering [Lottie](https://lottiefiles.github.io/lottie-docs/) and [dotLottie](https://dotlottie.io) animations in Node.js and web environments. It provides a simple and intuitive API for loading, playing, and controlling animations, as well as advanced features like interactivity and theming.
+`@lottiefiles/dotlottie-web` is a JavaScript library for rendering [Lottie](https://lottiefiles.github.io/lottie-docs/) and [dotLottie](https://lottiefiles.com/dotlottie) animations in Node.js and web environments. It provides a simple and intuitive API for loading, playing, and controlling animations, as well as advanced features like interactivity and theming.
 
 ### What is dotLottie?
 
 dotLottie is an open-source file format that bundles one or more Lottie animations along with their assets into a single, compressed .lottie file. It uses ZIP compression for efficient storage and distribution. The format also supports advanced features like interactivity and theming, making it a powerful tool for creating dynamic and interactive animations.
 
-[Learn more about dotLottie](https://dotlottie.io/).
+[Learn more about dotLottie](https://lottiefiles.com/dotlottie).
 
 ## Documentation
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/LottieFiles/dotlottie-web.git",
     "directory": "packages/web"
   },
-  "homepage": "https://developers.lottiefiles.com/docs/dotlottie-player/dotlottie-web/?utm_source=npm&utm_medium=package",
+  "homepage": "https://docs.lottiefiles.com/en/runtimes/distributions/js?utm_source=npm&utm_medium=package",
   "bugs": "https://github.com/LottieFiles/dotlottie-web/issues",
   "author": "LottieFiles",
   "contributors": [


### PR DESCRIPTION
Updates outbound links across the READMEs and package metadata:

- Replaces bare `https://dotlottie.io` links with `https://lottiefiles.com/dotlottie` (spec deep links left intact).
- Points each package `homepage` at its docs page under `https://docs.lottiefiles.com/en/runtimes/distributions/*` (solid → runtimes landing, no dedicated page yet).

The `[!TIP]` animation-library CTA is already present from #931.