### PR TITLE
fix(web): survive SWC minification of the player event loop

### DIFF
--- a/.changeset/fix-swc-event-binding-collapse.md
+++ b/.changeset/fix-swc-event-binding-collapse.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-web': patch
+---
+
+fix: read player event payloads synchronously so old SWC builds don't throw `null.frameNo` every frame

--- a/packages/web/src/dotlottie.ts
+++ b/packages/web/src/dotlottie.ts
@@ -290,10 +290,12 @@ export class DotLottie {
   private _drainPlayerEvents({ skipFrame = false }: { skipFrame?: boolean } = {}): void {
     if (!this._dotLottieCore) return;
 
-    let evt: unknown;
+    // Deferred callbacks must not read `event`: SWC <= 1.3.25 (Next.js 13.0.x) inlined the old
+    // function-scoped `let evt` alias into them, so they read the loop's null terminator. See #932.
+    for (;;) {
+      const event = this._dotLottieCore.poll_event() as { type: string; frameNo?: number; loopCount?: number } | null;
 
-    while ((evt = this._dotLottieCore.poll_event()) !== null && evt !== undefined) {
-      const event = evt as { type: string; frameNo?: number; loopCount?: number };
+      if (event == null) break;
 
       switch (event.type) {
         case 'Load':
@@ -316,21 +318,30 @@ export class DotLottie {
           queueMicrotask(() => this._eventManager.dispatch({ type: 'stop' }));
           break;
 
-        case 'Frame':
+        case 'Frame': {
+          const currentFrame = event.frameNo ?? 0;
+
           if (!skipFrame) {
-            queueMicrotask(() => this._eventManager.dispatch({ type: 'frame', currentFrame: event.frameNo ?? 0 }));
+            queueMicrotask(() => this._eventManager.dispatch({ type: 'frame', currentFrame }));
           }
           break;
+        }
 
-        case 'Render':
+        case 'Render': {
+          const currentFrame = event.frameNo ?? 0;
+
           if (!skipFrame) {
-            queueMicrotask(() => this._eventManager.dispatch({ type: 'render', currentFrame: event.frameNo ?? 0 }));
+            queueMicrotask(() => this._eventManager.dispatch({ type: 'render', currentFrame }));
           }
           break;
+        }
 
-        case 'Loop':
-          queueMicrotask(() => this._eventManager.dispatch({ type: 'loop', loopCount: event.loopCount ?? 0 }));
+        case 'Loop': {
+          const loopCount = event.loopCount ?? 0;
+
+          queueMicrotask(() => this._eventManager.dispatch({ type: 'loop', loopCount }));
           break;
+        }
 
         case 'Complete':
           queueMicrotask(() => this._eventManager.dispatch({ type: 'complete' }));
@@ -352,10 +363,8 @@ export class DotLottie {
     if (!this._dotLottieCore) return;
 
     // Drain state machine events
-    let evt: unknown;
-
-    while ((evt = this._dotLottieCore.sm_poll_event()) !== null && evt !== undefined) {
-      const event = evt as {
+    for (;;) {
+      const event = this._dotLottieCore.sm_poll_event() as {
         type: string;
         previousState?: string;
         newState?: string;
@@ -364,7 +373,9 @@ export class DotLottie {
         name?: string;
         oldValue?: unknown;
         newValue?: unknown;
-      };
+      } | null;
+
+      if (event == null) break;
 
       switch (event.type) {
         case 'Start':
@@ -446,10 +457,10 @@ export class DotLottie {
     }
 
     // Drain internal events
-    let internal: unknown;
+    for (;;) {
+      const internalEvt = this._dotLottieCore.sm_poll_internal_event() as { type: string; message?: string } | null;
 
-    while ((internal = this._dotLottieCore.sm_poll_internal_event()) !== null && internal !== undefined) {
-      const internalEvt = internal as { type: string; message?: string };
+      if (internalEvt == null) break;
 
       if (internalEvt.type === 'Message') {
         const message = internalEvt.message ?? '';


### PR DESCRIPTION
## Description

Fixes #932.

`_drainPlayerEvents` bound the polled event to a loop-scoped `let evt` and deferred reads of `event.frameNo` / `event.loopCount` into `queueMicrotask`. SWC **<= 1.3.25** — the version bundled with Next.js 13.0.x, where `swcMinify: true` is the default — inlines that binding back into the reassigned loop variable. The deferred callbacks then run after the loop has terminated and dereference its `null` terminator, throwing `Cannot read properties of null (reading 'frameNo')` on every frame.

Two changes, either of which is sufficient:

- bind the event per iteration (`for (;;)` + `const event = poll_event()`), so there is no loop variable to inline into;
- read `frameNo` / `loopCount` synchronously into a local before deferring, so the callbacks never touch the event object.

### Verification

Ran the built `dist/` through **next@13.0.6's own `@next/swc` binding** (the reporter's exact toolchain):

| | before | after |
|---|---|---|
| `dist/index.js` | `currentFrame:e.frameNo??0` where `e` is the poll variable — throws | `let n=e.frameNo??0; …currentFrame:n` — ok |
| `dist/webgl/index.js` | buggy | ok |
| `dist/webgpu/index.js` | buggy | ok |

Bisected the affected window: broken at @swc/core 1.3.3 / 1.3.10 / 1.3.20 / 1.3.25, **fixed upstream in 1.3.26**. Terser, esbuild and our own oxc/rolldown build never collapsed it.

Note the issue's claim that Next.js 15 will regress this is **not** correct — Next 15 ships a far newer SWC and is unaffected. This is a robustness fix so the library doesn't depend on minifier correctness in a per-frame path, not an urgent regression.

`_drainSmEvents` uses the same loop shape but reads every payload synchronously, so it is not affected today. Left unchanged to keep the diff tight.

## Package(s) affected

- [x] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [ ] `@lottiefiles/dotlottie-wc`

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [ ] Tests have been added or updated
- [x] Changeset has been added (if applicable)

No test added: the defect only exists in minifier output, so it is not reachable from the vitest suite. The guard is the source shape itself, documented by the comment on the loop. Existing suite passes — 330 passed, 50 skipped.