### PR TITLE
fix(wc): reflect and forward player state on element properties

### DIFF
--- a/.changeset/wc-getters-reflect-player-state.md
+++ b/.changeset/wc-getters-reflect-player-state.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/dotlottie-wc': patch
+---
+
+fix(wc): element properties read through to the live player and property writes are forwarded to it

--- a/packages/wc/README.md
+++ b/packages/wc/README.md
@@ -115,6 +115,24 @@ The `dotlottie-wc` exposes the following properties:
 | ------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `dotLottie`   | `DotLottie` | The dotLottie instance from [`DotLottie`](../web/README.md#documentation)  , allowing you to call methods and listen to events for more control over the animation. |
 
+Every attribute above is also a live property on the element: reads go through to the player once it
+is ready, and writes are forwarded to it — so framework property bindings (`.speed=${}` in Lit,
+`:speed` in Vue) work the same as attributes:
+
+```js
+const element = document.querySelector('dotlottie-wc');
+
+element.dotLottie.setSpeed(3);
+element.speed; // 3
+element.mode; // 'forward' — the player default, even with no `mode` attribute
+
+element.speed = 2; // same as element.dotLottie.setSpeed(2)
+```
+
+Two exceptions: `loopCount` reports the configured maximum you passed in, not
+`dotLottie.loopCount` (the number of loops completed so far), and reloading via a changed `src` or
+`data` attribute always re-applies the values declared in your markup, not the live player state.
+
 ### Custom WASM URL
 
 By default, the player's WebAssembly file is loaded from a CDN. If you need to serve it from your own host (e.g. environments where CDN access is restricted), use `setWasmUrl` before any animation loads:

--- a/packages/wc/__tests__/dotlottie-wc.spec.ts
+++ b/packages/wc/__tests__/dotlottie-wc.spec.ts
@@ -99,6 +99,137 @@ describe.each([
     expect(element.themeId).toBe('dark');
   });
 
+  test('getters read through to live dotLottie state after imperative changes', async () => {
+    const { element } = render(elementName, { src, loop: 'true', speed: '2' });
+
+    const dotLottie = element.dotLottie as DotLottie | DotLottieWorker;
+
+    await vi.waitFor(
+      () => {
+        expect(dotLottie.isLoaded).toBe(true);
+      },
+      { timeout: 5000 },
+    );
+
+    expect(element.autoplay).toBe(false);
+    expect(element.mode).toBe('forward');
+    expect(element.useFrameInterpolation).toBe(true);
+    expect(element.animationId).toBe('test');
+
+    dotLottie.setSpeed(3);
+    dotLottie.setLoop(false);
+    dotLottie.setMode('reverse');
+    dotLottie.setBackgroundColor('#00ff00');
+    dotLottie.setUseFrameInterpolation(false);
+    dotLottie.setMarker('Marker_1');
+
+    await vi.waitFor(
+      () => {
+        expect(element.speed).toBe(3);
+        expect(element.loop).toBe(false);
+        expect(element.mode).toBe('reverse');
+        expect(element.backgroundColor).toBe('#00ff00');
+        expect(element.useFrameInterpolation).toBe(false);
+        expect(element.marker).toBe('Marker_1');
+        expect(element.renderConfig).toEqual(dotLottie.renderConfig);
+      },
+      { timeout: 5000 },
+    );
+
+    // Checked separately: setMarker() overwrites the segment.
+    dotLottie.setSegment(0, 10);
+
+    await vi.waitFor(
+      () => {
+        expect(element.segment).toEqual([0, 10]);
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  test('property writes are forwarded to the player and read back', async () => {
+    const { element } = render(elementName, { src, loop: 'true' });
+
+    const dotLottie = element.dotLottie as DotLottie | DotLottieWorker;
+
+    await vi.waitFor(
+      () => {
+        expect(dotLottie.isLoaded).toBe(true);
+      },
+      { timeout: 5000 },
+    );
+
+    const fullRange = dotLottie.segment;
+
+    element.loop = false;
+    element.speed = 3;
+    element.mode = 'reverse';
+    element.segment = [0, 10];
+
+    await vi.waitFor(
+      () => {
+        expect(dotLottie.loop).toBe(false);
+        expect(dotLottie.speed).toBe(3);
+        expect(dotLottie.mode).toBe('reverse');
+        expect(dotLottie.segment).toEqual([0, 10]);
+      },
+      { timeout: 5000 },
+    );
+
+    expect(element.loop).toBe(false);
+    expect(element.speed).toBe(3);
+
+    element.segment = undefined;
+
+    await vi.waitFor(
+      () => {
+        expect(dotLottie.segment).toEqual(fullRange);
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  test('getters return declared attribute values after unmount destroys the instance', () => {
+    const { element, unmount } = render(elementName, { src, loop: 'true', speed: '2' });
+
+    unmount();
+
+    expect(element.dotLottie).toBeNull();
+    expect(element.loop).toBe(true);
+    expect(element.speed).toBe(2);
+  });
+
+  test('changing src reloads with declared attribute values, not mutated player state (issue #419)', async () => {
+    const { element, rerender } = render(elementName, { src, loop: 'true' });
+
+    const dotLottie = element.dotLottie as DotLottie | DotLottieWorker;
+
+    await vi.waitFor(
+      () => {
+        expect(dotLottie.isLoaded).toBe(true);
+      },
+      { timeout: 5000 },
+    );
+
+    dotLottie.setLoop(false);
+
+    await vi.waitFor(
+      () => {
+        expect(element.loop).toBe(false);
+      },
+      { timeout: 5000 },
+    );
+
+    rerender({ src: lottieSrc, loop: 'true' });
+
+    await vi.waitFor(
+      () => {
+        expect(element.loop).toBe(true);
+      },
+      { timeout: 5000 },
+    );
+  });
+
   test('calls dotLottie.destroy on unmount', async () => {
     const { element, unmount } = render(elementName, { src });
 

--- a/packages/wc/src/base-dotlottie-wc.ts
+++ b/packages/wc/src/base-dotlottie-wc.ts
@@ -1,12 +1,52 @@
-import type { Config, DotLottie, DotLottieWorker, Mode } from '@lottiefiles/dotlottie-web';
+import type { Config, DotLottie, DotLottieWorker } from '@lottiefiles/dotlottie-web';
 import type { TemplateResult } from 'lit';
 import { css, html, LitElement } from 'lit';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { property, state } from 'lit/decorators.js';
 
+type DeclaredConfig = Omit<Config, 'animationId' | 'canvas' | 'data' | 'src'>;
+
 export abstract class BaseDotLottieWC<T extends DotLottie | DotLottieWorker> extends LitElement {
+  private _animationId?: string;
+
+  private _loop: Config['loop'];
+
+  private _loopCount: Config['loopCount'];
+
+  private _autoplay: Config['autoplay'];
+
+  private _speed: Config['speed'];
+
+  private _segment: Config['segment'];
+
+  private _mode: Config['mode'];
+
+  private _marker: Config['marker'];
+
+  private _backgroundColor: Config['backgroundColor'];
+
+  private _renderConfig: Config['renderConfig'];
+
+  private _useFrameInterpolation: Config['useFrameInterpolation'];
+
+  private _themeId: Config['themeId'];
+
+  private _isPlayerReady(): boolean {
+    return this.dotLottie?.isReady ?? false;
+  }
+
   @property({ type: String })
-  public animationId?: string;
+  public get animationId(): string | undefined {
+    return this._isPlayerReady() ? this.dotLottie?.activeAnimationId : this._animationId;
+  }
+
+  public set animationId(value: string | undefined) {
+    this._animationId = value;
+
+    if (value && this.dotLottie && this.dotLottie.activeAnimationId !== value) {
+      this.dotLottie.loadAnimation(value);
+    }
+  }
 
   @property({ type: String })
   public src: Config['src'];
@@ -15,42 +55,127 @@ export abstract class BaseDotLottieWC<T extends DotLottie | DotLottieWorker> ext
   public data: Config['data'];
 
   @property({ type: Boolean })
-  public loop: Config['loop'];
+  public get loop(): Config['loop'] {
+    return this._isPlayerReady() ? this.dotLottie?.loop : this._loop;
+  }
 
+  public set loop(value: Config['loop']) {
+    this._loop = value;
+    this.dotLottie?.setLoop(value ?? false);
+  }
+
+  // Read is not delegated: dotLottie.loopCount counts completed loops, this is the configured maximum.
   @property({ type: Number })
-  public loopCount: Config['loopCount'];
+  public get loopCount(): Config['loopCount'] {
+    return this._loopCount;
+  }
+
+  public set loopCount(value: Config['loopCount']) {
+    this._loopCount = value;
+    this.dotLottie?.setLoopCount(value ?? 0);
+  }
 
   @property({ type: Boolean })
-  public autoplay: Config['autoplay'];
+  public get autoplay(): Config['autoplay'] {
+    return this._isPlayerReady() ? this.dotLottie?.autoplay : this._autoplay;
+  }
+
+  public set autoplay(value: Config['autoplay']) {
+    this._autoplay = value;
+  }
 
   @property({ type: Number })
-  public speed: Config['speed'];
+  public get speed(): Config['speed'] {
+    return this._isPlayerReady() ? this.dotLottie?.speed : this._speed;
+  }
+
+  public set speed(value: Config['speed']) {
+    this._speed = value;
+    this.dotLottie?.setSpeed(value ?? 1);
+  }
 
   @property({ type: Array })
-  public segment: Config['segment'];
+  public get segment(): Config['segment'] {
+    return this._isPlayerReady() ? this.dotLottie?.segment : this._segment;
+  }
+
+  public set segment(value: Config['segment']) {
+    this._segment = value;
+
+    if (!this.dotLottie) return;
+
+    if (Array.isArray(value) && value.length === 2 && typeof value[0] === 'number' && typeof value[1] === 'number') {
+      this.dotLottie.setSegment(value[0], value[1]);
+    } else {
+      this.dotLottie.resetSegment();
+    }
+  }
 
   @property({ type: String })
-  public mode: Config['mode'];
+  public get mode(): Config['mode'] {
+    return this._isPlayerReady() ? this.dotLottie?.mode : this._mode;
+  }
+
+  public set mode(value: Config['mode']) {
+    this._mode = value;
+    this.dotLottie?.setMode(value || 'forward');
+  }
 
   @property({ type: String })
-  public marker: Config['marker'];
+  public get marker(): Config['marker'] {
+    return this._isPlayerReady() ? this.dotLottie?.marker : this._marker;
+  }
+
+  public set marker(value: Config['marker']) {
+    this._marker = value;
+    this.dotLottie?.setMarker(value ?? '');
+  }
 
   @property({ type: String })
-  public backgroundColor: Config['backgroundColor'];
+  public get backgroundColor(): Config['backgroundColor'] {
+    return this._isPlayerReady() ? this.dotLottie?.backgroundColor : this._backgroundColor;
+  }
+
+  public set backgroundColor(value: Config['backgroundColor']) {
+    this._backgroundColor = value;
+    this.dotLottie?.setBackgroundColor(value ?? '');
+  }
 
   @property({ type: Object })
-  public renderConfig: Config['renderConfig'];
+  public get renderConfig(): Config['renderConfig'] {
+    return this._isPlayerReady() ? this.dotLottie?.renderConfig : this._renderConfig;
+  }
+
+  public set renderConfig(value: Config['renderConfig']) {
+    this._renderConfig = value;
+    this.dotLottie?.setRenderConfig(value ?? {});
+  }
 
   @property({
     type: Boolean,
     converter: {
-      fromAttribute: (value: string | null) => value !== null && value !== 'false',
+      // Removal leaves the property undeclared so the player default is restored.
+      fromAttribute: (value: string | null) => (value === null ? undefined : value !== 'false'),
     },
   })
-  public useFrameInterpolation: Config['useFrameInterpolation'];
+  public get useFrameInterpolation(): Config['useFrameInterpolation'] {
+    return this._isPlayerReady() ? this.dotLottie?.useFrameInterpolation : this._useFrameInterpolation;
+  }
+
+  public set useFrameInterpolation(value: Config['useFrameInterpolation']) {
+    this._useFrameInterpolation = value;
+    this.dotLottie?.setUseFrameInterpolation(value ?? true);
+  }
 
   @property({ type: String })
-  public themeId: Config['themeId'];
+  public get themeId(): Config['themeId'] {
+    return this._isPlayerReady() ? this.dotLottie?.activeThemeId : this._themeId;
+  }
+
+  public set themeId(value: Config['themeId']) {
+    this._themeId = value;
+    this.dotLottie?.setTheme(value ?? '');
+  }
 
   @property({ type: String })
   public workerId?: string;
@@ -76,29 +201,35 @@ export abstract class BaseDotLottieWC<T extends DotLottie | DotLottieWorker> ext
     }
   `;
 
+  private _declaredConfig(): DeclaredConfig {
+    return {
+      loop: this._loop,
+      loopCount: this._loopCount,
+      autoplay: this._autoplay,
+      speed: this._speed,
+      segment: this._segment,
+      marker: this._marker,
+      mode: this._mode,
+      renderConfig: this._renderConfig,
+      useFrameInterpolation: this._useFrameInterpolation,
+      themeId: this._themeId,
+      backgroundColor: this._backgroundColor,
+      stateMachineConfig: this.stateMachineConfig,
+      stateMachineId: this.stateMachineId,
+    };
+  }
+
   private _init(): void {
     const canvas = document.createElement('canvas');
 
     this.shadowRoot?.appendChild(canvas);
 
     this.dotLottie = this._createDotLottieInstance({
+      ...this._declaredConfig(),
       canvas,
       src: this.src,
       data: this.data,
-      loop: this.loop,
-      loopCount: this.loopCount,
-      autoplay: this.autoplay,
-      speed: this.speed,
-      segment: this.segment,
-      marker: this.marker,
-      mode: this.mode,
-      renderConfig: this.renderConfig,
-      useFrameInterpolation: this.useFrameInterpolation,
-      themeId: this.themeId,
-      animationId: this.animationId,
-      stateMachineConfig: this.stateMachineConfig,
-      stateMachineId: this.stateMachineId,
-      backgroundColor: this.backgroundColor,
+      animationId: this._animationId,
       workerId: this.workerId,
     });
   }
@@ -129,99 +260,20 @@ export abstract class BaseDotLottieWC<T extends DotLottie | DotLottieWorker> ext
       return;
     }
 
-    if (name === 'segment') {
-      const segment = JSON.parse(value ?? '[]');
-
-      if (
-        Array.isArray(segment) &&
-        segment.length === 2 &&
-        typeof segment[0] === 'number' &&
-        typeof segment[1] === 'number'
-      ) {
-        this.dotLottie.setSegment(segment[0], segment[1]);
-      } else {
-        this.dotLottie.resetSegment();
-      }
-    }
-
-    if (name === 'mode') {
-      this.dotLottie.setMode(value ? (value as Mode) : 'forward');
-    }
-
-    if (name === 'speed') {
-      this.dotLottie.setSpeed(value ? Number(value) : 1);
-    }
-
-    if (name === 'loop') {
-      this.dotLottie.setLoop(Boolean(value));
-    }
-
-    if (name === 'loopcount') {
-      this.dotLottie.setLoopCount(value ? Number(value) : 0);
-    }
-
-    if (name === 'useframeinterpolation') {
-      this.dotLottie.setUseFrameInterpolation(typeof value === 'string' ? JSON.parse(value) : true);
-    }
-
-    if (name === 'themeid') {
-      this.dotLottie.setTheme(value ?? '');
-    }
-
-    if (name === 'backgroundcolor') {
-      this.dotLottie.setBackgroundColor(value ?? '');
-    }
-
-    if (name === 'renderconfig') {
-      this.dotLottie.setRenderConfig(JSON.parse(value ?? '{}'));
-    }
-
-    if (name === 'animationid' && value) {
-      this.dotLottie.loadAnimation(value);
-    }
-
-    if (name === 'marker') {
-      this.dotLottie.setMarker(value ?? '');
-    }
-
     if (name === 'src' && value) {
       this.dotLottie.load({
+        ...this._declaredConfig(),
         src: value,
         data: this.data,
-        loop: this.loop,
-        loopCount: this.loopCount,
-        autoplay: this.autoplay,
-        speed: this.speed,
-        segment: this.segment,
-        marker: this.marker,
-        mode: this.mode,
-        renderConfig: this.renderConfig,
-        useFrameInterpolation: this.useFrameInterpolation,
-        themeId: this.themeId,
-        stateMachineConfig: this.stateMachineConfig,
-        stateMachineId: this.stateMachineId,
-        backgroundColor: this.backgroundColor,
       });
     }
 
     if (name === 'data' && value) {
       this.dotLottie.load({
+        ...this._declaredConfig(),
         src: this.src,
         data: value,
-        loop: this.loop,
-        loopCount: this.loopCount,
-        autoplay: this.autoplay,
-        speed: this.speed,
-        segment: this.segment,
-        marker: this.marker,
-        mode: this.mode,
-        renderConfig: this.renderConfig,
-        useFrameInterpolation: this.useFrameInterpolation,
-        themeId: this.themeId,
-        animationId: this.animationId,
-        stateMachineConfig: this.stateMachineConfig,
-        stateMachineId: this.stateMachineId,
-        backgroundColor: this.backgroundColor,
+        animationId: this._animationId,
       });
     }
 


### PR DESCRIPTION
## Description

Element properties on `dotlottie-wc` never reflected the player. `element.loop` returned whatever the markup declared (or `undefined`), and property writes like `element.speed = 3` were swallowed entirely.

Config properties are now accessor pairs — getters read through to the live `dotLottie` instance once it is ready, setters forward to it. Attributes reach the setters through Lit's attribute-to-property conversion, so the per-attribute blocks in `attributeChangedCallback` collapse into them and framework property bindings (`.speed=${}`, `:speed`) work for the first time.

Two deliberate exceptions: `loopCount` keeps reporting the configured maximum rather than `dotLottie.loopCount` (which counts completed loops), and reloads on `src`/`data` still re-apply the declared markup values, not mutated player state.

Fixes #419

## Package(s) affected

- [ ] `@lottiefiles/dotlottie-web` (core)
- [ ] `@lottiefiles/dotlottie-react`
- [ ] `@lottiefiles/dotlottie-vue`
- [ ] `@lottiefiles/dotlottie-svelte`
- [ ] `@lottiefiles/dotlottie-solid`
- [x] `@lottiefiles/dotlottie-wc`

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Chore (build, CI, docs, refactor)

## Checklist

- [x] Changes have been tested locally
- [x] Tests have been added or updated
- [x] Changeset has been added (if applicable)